### PR TITLE
Switch linux_ath10k to use linux_testing.

### DIFF
--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -109,7 +109,7 @@ let
     }
   );
 
-  linuxPackages_ath10k = super.recurseIntoAttrs (ath10kPackagesFor super.linux);
+  linuxPackages_ath10k = super.recurseIntoAttrs (ath10kPackagesFor super.linux_testing);
   linux_ath10k = linuxPackages_ath10k.kernel;
 
   linuxPackages_ath10k_ct = super.recurseIntoAttrs (ath10kPackagesFor (super.linux.override {


### PR DESCRIPTION
It's based on 5.7-rc6, and according to the OpenWRT forums, the
5.7-rc3 mac80211 driver seems to have fixed the official ath10k
firmware issues.