### PR TITLE
Override vscode.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@ in
 let
   overlays = self: super: lib.customisation.composeOverlays lib.overlays super;
   self = lib.customisation.composeOverlays (lib.singleton overlays) pkgs;
+
 in
 {
   inherit (self) awscli_2_0;
@@ -63,6 +64,7 @@ in
   inherit (self) trimpcap;
   inherit (self) tsoff;
   inherit (self) unison-ucm;
+  inherit (self) vscode vscode-with-extensions vscode-extensions vscode-with-python;
   inherit (self) wpa_supplicant;
   inherit (self) yubikey-manager;
 

--- a/overlays/overrides.nix
+++ b/overlays/overrides.nix
@@ -25,42 +25,39 @@ let
 
   # Upstream doesn't support macOS, probably due to
   # https://github.com/radareorg/radare2/issues/15197
-  radare2 = super.radare2.overrideAttrs
-    (
-      drv: {
-        python3 = super.python3;
-        useX11 = false;
-        pythonBindings = true;
-        luaBindings = true;
+  radare2 = super.radare2.overrideAttrs (
+    drv: {
+      python3 = super.python3;
+      useX11 = false;
+      pythonBindings = true;
+      luaBindings = true;
 
-        # XXX dhess - this is a bit of a hack.
-        HOST_CC = if super.stdenv.cc.isClang then "clang" else "gcc";
+      # XXX dhess - this is a bit of a hack.
+      HOST_CC = if super.stdenv.cc.isClang then "clang" else "gcc";
 
-        meta = drv.meta // { platforms = super.lib.platforms.unix; };
-      }
-    );
+      meta = drv.meta // { platforms = super.lib.platforms.unix; };
+    }
+  );
 
   # Upstream prevents fsatrace from building on macOS. It should work,
   # more or less, as long as you're using it with binaries built from
   # Nixpkgs and not pulling in Apple frameworks.
-  fsatrace = super.fsatrace.overrideAttrs
-    (drv: { meta = drv.meta // { platforms = super.lib.platforms.unix; }; });
+  fsatrace = super.fsatrace.overrideAttrs (drv: { meta = drv.meta // { platforms = super.lib.platforms.unix; }; });
 
   # We need YubiKey OpenPGP KDF functionality, which hasn't been
   # released yet.
-  yubikey-manager = super.yubikey-manager.overrideAttrs
-    (
-      drv: {
-        version = "3.1.1";
-        name = "yubikey-manager-3.1.1";
-        srcs = super.fetchFromGitHub {
-          owner = "Yubico";
-          repo = "yubikey-manager";
-          rev = "2bbab3072ea0ec7cdcbaba398ce8dc0105aa27c2";
-          sha256 = "1i4qfmmwiw3pfbhzyivw6qp3zc17qv38sgxvza1lb2hl577za9y1";
-        };
-      }
-    );
+  yubikey-manager = super.yubikey-manager.overrideAttrs (
+    drv: {
+      version = "3.1.1";
+      name = "yubikey-manager-3.1.1";
+      srcs = super.fetchFromGitHub {
+        owner = "Yubico";
+        repo = "yubikey-manager";
+        rev = "2bbab3072ea0ec7cdcbaba398ce8dc0105aa27c2";
+        sha256 = "1i4qfmmwiw3pfbhzyivw6qp3zc17qv38sgxvza1lb2hl577za9y1";
+      };
+    }
+  );
   oldNixUnstable = (
     super.callPackage ../pkgs/nix {
       storeDir = "/nix/store";
@@ -81,36 +78,53 @@ let
   unison-ucm = super.callPackage ../pkgs/unison { };
 
   # Enable TLS v1.2 in wpa_supplicant.
-  wpa_supplicant = super.wpa_supplicant.overrideAttrs
-    (
-      drv: {
-        extraConfig = drv.extraConfig + ''
-          CONFIG_TLSV12=y
-        '';
-      }
-    );
-  hostapd = super.hostapd.overrideAttrs
-    (
-      drv: {
-        extraConfig = drv.extraConfig + ''
-          CONFIG_DRIVER_NL80211_QCA=y
-          CONFIG_SAE=y
-          CONFIG_SUITEB192=y
-          CONFIG_IEEE80211AX=y
-          CONFIG_DEBUG_LINUX_TRACING=y
-          CONFIG_FST=y
-          CONFIG_FST_TEST=y
-          CONFIG_MBO=y
-          CONFIG_TAXONOMY=y
-          CONFIG_FILS=y
-          CONFIG_FILS_SK_PFS=y
-          CONFIG_WPA_CLI_EDIT=y
-          CONFIG_OWE=y
-          CONFIG_AIRTIME_POLICY=y
-          CONFIG_NO_TKIP=y
-        '';
-      }
-    );
+  wpa_supplicant = super.wpa_supplicant.overrideAttrs (
+    drv: {
+      extraConfig = drv.extraConfig + ''
+        CONFIG_TLSV12=y
+      '';
+    }
+  );
+  hostapd = super.hostapd.overrideAttrs (
+    drv: {
+      extraConfig = drv.extraConfig + ''
+        CONFIG_DRIVER_NL80211_QCA=y
+        CONFIG_SAE=y
+        CONFIG_SUITEB192=y
+        CONFIG_IEEE80211AX=y
+        CONFIG_DEBUG_LINUX_TRACING=y
+        CONFIG_FST=y
+        CONFIG_FST_TEST=y
+        CONFIG_MBO=y
+        CONFIG_TAXONOMY=y
+        CONFIG_FILS=y
+        CONFIG_FILS_SK_PFS=y
+        CONFIG_WPA_CLI_EDIT=y
+        CONFIG_OWE=y
+        CONFIG_AIRTIME_POLICY=y
+        CONFIG_NO_TKIP=y
+      '';
+    }
+  );
+
+  # Upstream is broken:
+  # https://github.com/NixOS/nixpkgs/pull/71264/files
+  vscode = callPackage ../pkgs/vscode/vscode.nix { };
+  vscode-with-extensions = callPackage ../pkgs/vscode/with-extensions.nix {
+    inherit vscode;
+  };
+
+  # Upstream is broken, and a bit out of date.
+  vscode-extensions = super.recurseIntoAttrs (super.vscode-extensions // {
+    ms-python = super.vscode-extensions.ms-python // {
+      python = callPackage ../pkgs/vscode-python { };
+    };
+  });
+
+  vscode-with-python = self.vscode-with-extensions.override {
+    vscodeExtensions = super.lib.singleton self.vscode-extensions.ms-python.python;
+  };
+
 in
 {
   # Use fdk_aac in ffmpeg-full.
@@ -140,6 +154,7 @@ in
   inherit minikube;
   inherit radare2;
   inherit unison-ucm;
+  inherit vscode vscode-with-extensions vscode-extensions vscode-with-python;
   inherit wpa_supplicant;
   inherit yubikey-manager;
 }

--- a/pkgs/vscode-python/default.nix
+++ b/pkgs/vscode-python/default.nix
@@ -1,0 +1,121 @@
+{ lib
+, stdenv
+, fetchurl
+, runCommand
+, unzip
+, vscode-utils
+, icu
+, curl
+, openssl
+, lttng-ust
+, musl
+, autoPatchelfHook
+, python3
+, pythonUseFixed ? true       # When `true`, the python default setting will be fixed to specified.
+  # Use version from `PATH` for default setting otherwise.
+  # Defaults to `false` as we expect it to be project specific most of the time.
+, ctagsUseFixed ? true
+, ctags  # When `true`, the ctags default setting will be fixed to specified.
+  # Use version from `PATH` for default setting otherwise.
+  # Defaults to `true` as usually not defined on a per projet basis.
+}:
+
+assert ctagsUseFixed -> null != ctags;
+let
+  extractNuGet = { name, version, src, ... }: stdenv.mkDerivation {
+    inherit name version src;
+
+    buildInputs = [ unzip ];
+    dontBuild = true;
+    unpackPhase = "unzip $src";
+    installPhase = ''
+      mkdir -p "$out"
+      chmod -R +w .
+      find . -mindepth 1 -maxdepth 1 | xargs cp -a -t "$out"
+    '';
+  };
+
+  pythonDefaultsTo = if pythonUseFixed then "${python3}/bin/python" else "python";
+  ctagsDefaultsTo = if ctagsUseFixed then "${ctags}/bin/ctags" else "ctags";
+
+  # The arch tag comes from 'PlatformName' defined here:
+  # https://github.com/Microsoft/vscode-python/blob/master/src/client/activation/types.ts
+  arch =
+    if stdenv.isLinux && stdenv.isx86_64 then "linux-x64"
+    else if stdenv.isDarwin then "osx-x64"
+    else throw "Only x86_64 Linux and Darwin are supported.";
+
+  languageServerSha256 = {
+    linux-x64 = "0x4269swyciwhzlwjrl5fmbli4p9qvycx0cr9ywlyd7q353jz4r7";
+    osx-x64 = "1ixkh6kzcbjql4kmpkckbv32423vl6z7jf3j0bdb1705bfyw97xg";
+  }.${arch};
+
+  languageServer = extractNuGet rec {
+    name = "Python-Language-Server";
+    version = "0.5.50";
+
+    src = fetchurl {
+      url = "https://pvsc.azureedge.net/python-language-server-stable/${name}-${arch}.${version}.nupkg";
+      sha256 = languageServerSha256;
+    };
+  };
+
+  libcMusl =
+    runCommand "libc-musl-x86_64"
+      { } ''
+      mkdir -p $out/lib
+      cp -pdv ${musl}/lib/libc.so $out/lib/libc.musl-x86_64.so.1
+      ln -s $out/lib/libc.musl-x86_64.so.1 $out/lib/libc.musl-x86_64.so
+    '';
+in
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "python";
+    publisher = "ms-python";
+    version = "2020.5.80290";
+    sha256 = "0ybr8f1ki70dqwkh34q3p1liv81jr0jfxhavy79n08l3lalrwkb1";
+  };
+
+  buildInputs = [
+    icu
+    curl
+    openssl
+  ] ++ lib.optional stdenv.isLinux [
+    lttng-ust
+    libcMusl
+  ];
+
+  nativeBuildInputs = [
+    python3.pkgs.wrapPython
+  ] ++ lib.optional stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  pythonPath = with python3.pkgs; [
+    setuptools
+  ];
+
+  postPatch = ''
+    # Patch `packages.json` so that nix's *python* is used as default value for `python.pythonPath`.
+    substituteInPlace "./package.json" \
+      --replace "\"default\": \"python\"" "\"default\": \"${pythonDefaultsTo}\""
+
+    # Patch `packages.json` so that nix's *ctags* is used as default value for `python.workspaceSymbols.ctagsPath`.
+    substituteInPlace "./package.json" \
+      --replace "\"default\": \"ctags\"" "\"default\": \"${ctagsDefaultsTo}\""
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/$installPrefix/languageServer.${languageServer.version}"
+    cp -R --no-preserve=ownership ${languageServer}/* "$out/$installPrefix/languageServer.${languageServer.version}"
+    chmod a+x "$out/$installPrefix/languageServer.${languageServer.version}/Microsoft.Python.LanguageServer"
+
+    patchPythonScript "$out/$installPrefix/pythonFiles/lib/python/isort/main.py"
+  '';
+
+  meta = with lib; {
+    license = licenses.mit;
+    maintainers = [ maintainers.dhess ];
+    platforms = with platforms; [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/vscode/generic.nix
+++ b/pkgs/vscode/generic.nix
@@ -1,0 +1,112 @@
+{ stdenv
+, lib
+, makeDesktopItem
+, unzip
+, libsecret
+, libXScrnSaver
+, wrapGAppsHook
+, gtk2
+, atomEnv
+, at-spi2-atk
+, autoPatchelfHook
+, systemd
+, fontconfig
+
+  # Attributes inherit from specific versions
+, version
+, src
+, meta
+, sourceRoot
+, executableName
+, longName
+, shortName
+, pname
+}:
+let
+  inherit (stdenv.hostPlatform) system;
+in
+stdenv.mkDerivation {
+
+  inherit pname version src sourceRoot;
+
+  passthru = {
+    inherit executableName longName;
+  };
+
+  desktopItem = makeDesktopItem {
+    name = executableName;
+    desktopName = longName;
+    comment = "Code Editing. Redefined.";
+    genericName = "Text Editor";
+    exec = executableName;
+    icon = "code";
+    startupNotify = "true";
+    categories = "Utility;TextEditor;Development;IDE;";
+    mimeType = "text/plain;inode/directory;";
+    extraEntries = ''
+      StartupWMClass=${shortName}
+      Actions=new-empty-window;
+      Keywords=vscode;
+
+      [Desktop Action new-empty-window]
+      Name=New Empty Window
+      Exec=${executableName} --new-window %F
+      Icon=code
+    '';
+  };
+
+  urlHandlerDesktopItem = makeDesktopItem {
+    name = executableName + "-url-handler";
+    desktopName = longName + " - URL Handler";
+    comment = "Code Editing. Redefined.";
+    genericName = "Text Editor";
+    exec = executableName + " --open-url %U";
+    icon = "code";
+    startupNotify = "true";
+    categories = "Utility;TextEditor;Development;IDE;";
+    mimeType = "x-scheme-handler/vscode;";
+    extraEntries = ''
+      NoDisplay=true
+      Keywords=vscode;
+    '';
+  };
+
+  buildInputs = (
+    if stdenv.isDarwin
+    then [ unzip ]
+    else [ gtk2 at-spi2-atk wrapGAppsHook ] ++ atomEnv.packages
+  )
+  ++ [ libsecret libXScrnSaver ];
+
+  runtimeDependencies = lib.optional (stdenv.isLinux) [ systemd.lib fontconfig.lib ];
+
+  nativeBuildInputs = lib.optional (!stdenv.isDarwin) autoPatchelfHook;
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase =
+    if system == "x86_64-darwin" then ''
+      mkdir -p "$out/Applications/${longName}.app" $out/bin
+      cp -r ./* "$out/Applications/${longName}.app"
+      ln -s "$out/Applications/${longName}.app/Contents/Resources/app/bin/code" $out/bin/${executableName}
+    '' else ''
+      mkdir -p $out/lib/vscode $out/bin
+      cp -r ./* $out/lib/vscode
+
+      ln -s $out/lib/vscode/bin/${executableName} $out/bin
+
+      mkdir -p $out/share/applications
+      ln -s $desktopItem/share/applications/${executableName}.desktop $out/share/applications/${executableName}.desktop
+      ln -s $urlHandlerDesktopItem/share/applications/${executableName}-url-handler.desktop $out/share/applications/${executableName}-url-handler.desktop
+
+      mkdir -p $out/share/pixmaps
+      cp $out/lib/vscode/resources/app/resources/linux/code.png $out/share/pixmaps/code.png
+
+      # Override the previously determined VSCODE_PATH with the one we know to be correct
+      sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/vscode'" $out/bin/${executableName}
+      grep -q "VSCODE_PATH='$out/lib/vscode'" $out/bin/${executableName} # check if sed succeeded
+    '';
+
+  inherit meta;
+}

--- a/pkgs/vscode/vscode.nix
+++ b/pkgs/vscode/vscode.nix
@@ -1,0 +1,56 @@
+{ stdenv, lib, callPackage, fetchurl, isInsiders ? false }:
+let
+  inherit (stdenv.hostPlatform) system;
+
+  plat = {
+    x86_64-linux = "linux-x64";
+    x86_64-darwin = "darwin";
+  }.${system};
+
+  archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
+
+  sha256 = {
+    x86_64-linux = "0zdg6z6h0h8vvwdrnihwd76bik41spv6xbw7cdh7hz97sjsh15zq";
+    x86_64-darwin = "1c5c24vj8nqsxx8hwfj04as7vsl9gnl97yniw36pdfgv88v8qzin";
+  }.${system};
+in
+callPackage ./generic.nix rec {
+  # The update script doesn't correctly change the hash for darwin, so please:
+  # nixpkgs-update: no auto update
+
+  # Please backport all compatible updates to the stable release.
+  # This is important for the extension ecosystem.
+  version = "1.45.1";
+  pname = "vscode";
+
+  executableName = "code" + lib.optionalString isInsiders "-insiders";
+  longName = "Visual Studio Code" + lib.optionalString isInsiders " - Insiders";
+  shortName = "Code" + lib.optionalString isInsiders " - Insiders";
+
+  src = fetchurl {
+    name = "VSCode_${version}_${plat}.${archive_fmt}";
+    url = "https://vscode-update.azurewebsites.net/${version}/${plat}/stable";
+    inherit sha256;
+  };
+
+  sourceRoot = "";
+
+  meta = with lib; {
+    description = ''
+      Open source source code editor developed by Microsoft for Windows,
+      Linux and macOS
+    '';
+    longDescription = ''
+      Open source source code editor developed by Microsoft for Windows,
+      Linux and macOS. It includes support for debugging, embedded Git
+      control, syntax highlighting, intelligent code completion, snippets,
+      and code refactoring. It is also customizable, so users can change the
+      editor's theme, keyboard shortcuts, and preferences
+    '';
+    homepage = "https://code.visualstudio.com/";
+    downloadPage = "https://code.visualstudio.com/Updates";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ dhess ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/vscode/with-extensions.nix
+++ b/pkgs/vscode/with-extensions.nix
@@ -1,0 +1,92 @@
+{ lib
+, stdenv
+, runCommand
+, buildEnv
+, vscode
+, makeWrapper
+, vscodeExtensions ? [ ]
+}:
+
+/*
+  `vscodeExtensions`
+   :  A set of vscode extensions to be installed alongside the editor. Here's a an
+      example:
+
+      ~~~
+      vscode-with-extensions.override {
+
+        # When the extension is already available in the default extensions set.
+        vscodeExtensions = with vscode-extensions; [
+          bbenoist.Nix
+        ]
+
+        # Concise version from the vscode market place when not available in the default set.
+        ++ vscode-utils.extensionsFromVscodeMarketplace [
+          {
+            name = "code-runner";
+            publisher = "formulahendry";
+            version = "0.6.33";
+            sha256 = "166ia73vrcl5c9hm4q1a73qdn56m0jc7flfsk5p5q41na9f10lb0";
+          }
+        ];
+      }
+      ~~~
+
+      This expression should fetch
+       -  the *nix* vscode extension from whatever source defined in the
+          default nixpkgs extensions set `vscodeExtensions`.
+
+       -  the *code-runner* vscode extension from the marketplace using the
+          following url:
+
+          ~~~
+          https://bbenoist.gallery.vsassets.io/_apis/public/gallery/publisher/bbenoist/extension/nix/1.0.1/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage
+          ~~~
+
+      The original `code` executable will be wrapped so that it uses the set of pre-installed / unpacked
+      extensions as its `--extensions-dir`.
+*/
+let
+  inherit (stdenv.hostPlatform) system;
+  inherit (vscode) executableName longName;
+  wrappedPkgVersion = lib.getVersion vscode;
+  wrappedPkgName = lib.removeSuffix "-${wrappedPkgVersion}" vscode.name;
+
+  combinedExtensionsDrv = buildEnv {
+    name = "vscode-extensions";
+    paths = vscodeExtensions;
+  };
+
+  extensionsFlag = lib.optionalString (vscodeExtensions != [ ]) ''
+    --add-flags "--extensions-dir ${combinedExtensionsDrv}"
+  '';
+in
+# When no extensions are requested, we simply redirect to the original
+  # non-wrapped vscode executable.
+runCommand "${wrappedPkgName}-with-extensions-${wrappedPkgVersion}"
+{
+  buildInputs = [ vscode makeWrapper ];
+  dontPatchELF = true;
+  dontStrip = true;
+  meta = vscode.meta;
+}
+  (
+    if system == "x86_64-darwin" then ''
+      mkdir -p $out/bin/
+      mkdir -p "$out/Applications/${longName}.app/Contents/MacOS"
+      for path in PkgInfo Frameworks Resources _CodeSignature Info.plist; do
+        ln -s "${vscode}/Applications/${longName}.app/Contents/$path" "$out/Applications/${longName}.app/Contents/"
+      done
+      makeWrapper "${vscode}/bin/${executableName}" "$out/bin/${executableName}" ${extensionsFlag}
+      makeWrapper "${vscode}/Applications/${longName}.app/Contents/MacOS/Electron" "$out/Applications/${longName}.app/Contents/MacOS/Electron" ${extensionsFlag}
+    '' else ''
+      mkdir -p "$out/bin"
+      mkdir -p "$out/share/applications"
+      mkdir -p "$out/share/pixmaps"
+
+      ln -sT "${vscode}/share/pixmaps/code.png" "$out/share/pixmaps/code.png"
+      ln -sT "${vscode}/share/applications/${executableName}.desktop" "$out/share/applications/${executableName}.desktop"
+      ln -sT "${vscode}/share/applications/${executableName}-url-handler.desktop" "$out/share/applications/${executableName}-url-handler.desktop"
+      makeWrapper "${vscode}/bin/${executableName}" "$out/bin/${executableName}" ${extensionsFlag}
+    ''
+  )

--- a/release.nix
+++ b/release.nix
@@ -29,85 +29,88 @@ let
   x86_64_linux = [ "x86_64-linux" ];
   linux = [ "x86_64-linux" ];
   jobs = (
-    mapTestOn
-      (
-        rec {
-          awscli_2_0 = all;
-          aws-sso-credential-process = all;
-          aws-export-credentials = all;
-          aws-vault = all;
+    mapTestOn (
+      rec {
+        awscli_2_0 = all;
+        aws-sso-credential-process = all;
+        aws-export-credentials = all;
+        aws-vault = all;
 
-          badhosts-unified = all;
-          badhosts-fakenews = all;
-          badhosts-gambling = all;
-          badhosts-nsfw = all;
-          badhosts-social = all;
-          badhosts-fakenews-gambling = all;
-          badhosts-fakenews-nsfw = all;
-          badhosts-fakenews-social = all;
-          badhosts-gambling-nsfw = all;
-          badhosts-gambling-social = all;
-          badhosts-nsfw-social = all;
-          badhosts-fakenews-gambling-nsfw = all;
-          badhosts-fakenews-gambling-social = all;
-          badhosts-fakenews-nsfw-social = all;
-          badhosts-gambling-nsfw-social = all;
-          badhosts-fakenews-gambling-nsfw-social = all;
-          badhosts-all = all;
+        badhosts-unified = all;
+        badhosts-fakenews = all;
+        badhosts-gambling = all;
+        badhosts-nsfw = all;
+        badhosts-social = all;
+        badhosts-fakenews-gambling = all;
+        badhosts-fakenews-nsfw = all;
+        badhosts-fakenews-social = all;
+        badhosts-gambling-nsfw = all;
+        badhosts-gambling-social = all;
+        badhosts-nsfw-social = all;
+        badhosts-fakenews-gambling-nsfw = all;
+        badhosts-fakenews-gambling-social = all;
+        badhosts-fakenews-nsfw-social = all;
+        badhosts-gambling-nsfw-social = all;
+        badhosts-fakenews-gambling-nsfw-social = all;
+        badhosts-all = all;
 
-          cachix = all;
-          ccextractor = x86_64;
-          cfssl = all;
-          chamber = all;
-          delete-tweets = all;
-          ffmpeg-full = x86_64;
-          fsatrace = all;
-          gawk_4_2_1 = all;
-          hostapd = linux;
-          hydra-unstable = x86_64_linux;
-          libprelude = x86_64_linux;
-          libvmaf = x86_64;
-          linux_ath10k = linux;
-          linux_ath10k_ct = linux;
-          lorri = all;
-          macnix-rebuild = darwin;
-          neovim = all;
-          netsniff-ng = x86_64_linux;
-          # NixOps doesn't evaluate on Hydra at the moment.
-          #nixops = x86_64;
-          nmrpflash = all;
-          ntp = linux;
-          radare2 = all;
-          traefik-forward-auth = all;
-          trimpcap = linux;
-          tsoff = linux;
-          unison-ucm = x86_64;
-          wpa_supplicant = linux;
-          yubikey-manager = all;
+        cachix = all;
+        ccextractor = x86_64;
+        cfssl = all;
+        chamber = all;
+        delete-tweets = all;
+        ffmpeg-full = x86_64;
+        fsatrace = all;
+        gawk_4_2_1 = all;
+        hostapd = linux;
+        hydra-unstable = x86_64_linux;
+        libprelude = x86_64_linux;
+        libvmaf = x86_64;
+        linux_ath10k = linux;
+        linux_ath10k_ct = linux;
+        lorri = all;
+        macnix-rebuild = darwin;
+        neovim = all;
+        netsniff-ng = x86_64_linux;
+        # NixOps doesn't evaluate on Hydra at the moment.
+        #nixops = x86_64;
+        nmrpflash = all;
+        ntp = linux;
+        radare2 = all;
+        traefik-forward-auth = all;
+        trimpcap = linux;
+        tsoff = linux;
+        unison-ucm = x86_64;
+        wpa_supplicant = linux;
+        yubikey-manager = all;
 
-          emacs = darwin;
-          emacs-env = darwin;
-          emacs-nox = linux;
-          emacs-nox-env = linux;
-          emacs-macport-env = darwin;
+        emacs = darwin;
+        emacs-env = darwin;
+        emacs-nox = linux;
+        emacs-nox-env = linux;
+        emacs-macport-env = darwin;
 
-          hyperkit = darwin;
-          minikube = all;
+        hyperkit = darwin;
+        minikube = all;
 
-          anki-env = darwin;
-          mactools-env = darwin;
-          maths-env = x86_64;
-          minikube-env = all;
-          nixtools-env = all;
-          opsec-env = all;
-          shell-env = darwin;
+        vscode = all;
+        vscode-with-extensions = all;
+        vscode-with-python = x86_64;
 
-          hacknix-source = all;
+        anki-env = darwin;
+        mactools-env = darwin;
+        maths-env = x86_64;
+        minikube-env = all;
+        nixtools-env = all;
+        opsec-env = all;
+        shell-env = darwin;
 
-          examples.nix-darwin.build-host.system = darwin;
-          examples.nix-darwin.remote-builder.system = darwin;
-        }
-      )
+        hacknix-source = all;
+
+        examples.nix-darwin.build-host.system = darwin;
+        examples.nix-darwin.remote-builder.system = darwin;
+      }
+    )
   ) // (
     rec {
       x86_64-linux = pkgs.releaseTools.aggregate {


### PR DESCRIPTION
This override works on macOS.

Note, however, that the Python plugin is broken, as it requires a
writable extensions directory.