### PR TITLE
Run GitHub Actions on macOS.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,10 @@ on:
   push:
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2.3.2
     - uses: cachix/install-nix-action@v10


### PR DESCRIPTION
Note that there are a few macOS packages that don't build at the moment, so the action currently fails, but the action bit is working, anyway.