### PR TITLE
Add --keep-going to GitHub action.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,4 +17,4 @@ jobs:
       with:
         name: hackworthltd-public
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY_HACKWORTH_PUBLIC }}'
-    - run: nix-build ci.nix
+    - run: nix-build ci.nix --keep-going


### PR DESCRIPTION
This will allow the action to make as much forward progress as
possible in the event of failed builds. It's useful because the
start-up time of Nix CI jobs on public GitHub builders is pretty
expensive.