### PR TITLE
Switch back to upstream NixOps and add an example NixOps network.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -80,5 +80,7 @@
 
   inherit (pkgs) macos-remote-builder macos-build-host;
 
+  inherit (pkgs) nixops-network-deployments;
+
   overlays.all = localLib.overlays;
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -41,6 +41,7 @@ let
       ../overlays/build-support.nix
       ../overlays/build-envs.nix
       ../overlays/nix-darwin-examples.nix
+      ../overlays/nixops-examples.nix
     ]
   );
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -132,15 +132,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixops": {
-        "branch": "eval-machine-info",
-        "description": "NixOps, the NixOS-based cloud deployment tool",
+        "branch": "master",
+        "description": "NixOps is a tool for deploying to NixOS machines in a network or cloud.",
         "homepage": "https://nixos.org/nixops",
-        "owner": "dhess",
+        "owner": "NixOS",
         "repo": "nixops",
-        "rev": "aff261b9eafa32df1317f3b57d90ea0f145b59b3",
-        "sha256": "109pbjv2kdlk2ncxlhcy4af10wav6s5ly45xh27w543npgr1azak",
+        "rev": "d5baedfa79c32327e23d34813a7e75f5979f7560",
+        "sha256": "11406540qp07s97pm15glqh57hv3smlc86hnxi6w1wxxwp2wkgcq",
         "type": "tarball",
-        "url": "https://github.com/dhess/nixops/archive/aff261b9eafa32df1317f3b57d90ea0f145b59b3.tar.gz",
+        "url": "https://github.com/NixOS/nixops/archive/d5baedfa79c32327e23d34813a7e75f5979f7560.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/overlays/custom-packages.nix
+++ b/overlays/custom-packages.nix
@@ -4,7 +4,7 @@ let
 
   inherit (super) callPackage;
   nixpkgsPath = (import lib.fixedNixpkgs { }).path;
-  nixops = import lib.fixedNixOps { nixpkgs = nixpkgsPath; };
+  nixops = import lib.fixedNixOps;
   lorri = (import lib.fixedLorri) { pkgs = super; };
   gawk_4_2_1 = callPackage ../pkgs/gawk/4.2.1.nix { };
   libprelude =

--- a/overlays/lib/hacknix.nix
+++ b/overlays/lib/hacknix.nix
@@ -29,6 +29,16 @@ let
       system = "x86_64-darwin";
       inherit configuration;
     };
+
+  # Make NixOps deployments buildable in Hydra.
+  deployments = network:
+    super.recurseIntoAttrs
+      (
+        super.lib.mapAttrs (super.lib.const (n: n.config.system.build.toplevel))
+          network.nodes
+      );
+  network = import (localLib.fixedNixOps + "/nix/eval-machine-info.nix");
+
 in
 {
   lib = (super.lib or { }) // {
@@ -47,6 +57,10 @@ in
 
       # Provide access to our nix-darwin, if anyone downstream wants to use it.
       inherit (localLib) nix-darwin;
+
+      nixops = (super.lib.hacknix.nixops or { }) // {
+        inherit deployments network;
+      };
 
       testing = (super.lib.hacknix.testing or { }) // {
         inherit testModules testModulesList;

--- a/overlays/nixops-examples.nix
+++ b/overlays/nixops-examples.nix
@@ -1,0 +1,18 @@
+self: super:
+let
+  nixops-network = super.lib.hacknix.nixops.network {
+    pluginNixExprs = [ ];
+    networkExprs = [
+      ./nixops/logical.nix
+      ./nixops/physical.nix
+    ];
+    uuid = "dummy";
+    deploymentName = "nixops-network-deployments";
+    args = { };
+  };
+  nixops-network-deployments = super.lib.hacknix.nixops.deployments nixops-network;
+
+in
+{
+  inherit nixops-network-deployments;
+}

--- a/overlays/nixops/logical.nix
+++ b/overlays/nixops/logical.nix
@@ -1,0 +1,26 @@
+{ system ? "x86_64-linux"
+, config ? {
+    allowUnfree = true;
+  }
+, localLib ? import ../../nix/default.nix { inherit system config; }
+, pkgs ? localLib.pkgs
+}:
+let
+  ourModules = import ../../modules/module-list.nix;
+in
+{
+  network = {
+    description = "hacknix test deployment.";
+    nixpkgs = pkgs;
+    enableRollback = true;
+  };
+
+  defaults = { ... }: {
+    imports = ourModules;
+  };
+
+  machine1 = { ... }: {
+    networking.hostName = "foo";
+    networking.domain = "example.com";
+  };
+}

--- a/overlays/nixops/physical.nix
+++ b/overlays/nixops/physical.nix
@@ -1,0 +1,25 @@
+{ system ? "x86_64-linux"
+, config ? {
+    allowUnfree = true;
+  }
+, localLib ? import ../../nix/default.nix { inherit system config; }
+, pkgs ? localLib.pkgs
+}:
+
+{
+  machine1 = { ... }: {
+    config = {
+      nixpkgs.config.allowUnfree = true;
+      hacknix.hardware = {
+        hwutils.enable = true;
+        mbr.enable = true;
+        apu2.apu3c4.enable = true;
+      };
+      fileSystems."/" = {
+        device = "/dev/disk/by-label/nixos";
+        fsType = "ext4";
+      };
+      boot.loader.grub.devices = [ "/dev/sda" ];
+    };
+  };
+}


### PR DESCRIPTION
The example NixOps network lets us test our modules etc on Hydra.