### PR TITLE
Fix niv update GitHub Action.

### DIFF
--- a/.github/workflows/bump-deps.yaml
+++ b/.github/workflows/bump-deps.yaml
@@ -10,7 +10,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.2
     - uses: cachix/install-nix-action@v10
-    - run: nix-shell --run "niv update"
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v1.1.0
+      with:
+        app_id: ${{ secrets.TOKEN_GENERATOR_ID }}
+        private_key: ${{ secrets.TOKEN_GENERATOR_KEY }}
+    - run: GITHUB_TOKEN=${{ steps.generate_token.outputs.token }} nix-shell --run "niv update"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3.3.0
       with:


### PR DESCRIPTION
For some unknown reason, sometime in the last few days, running niv on
a GitHub Actions runner requires a GITHUB_TOKEN. Rather than using a
personal access token from my account or the Hackworth Ltd bot's
account, we use the tibdex/github-app-token action to create a
one-time-use token.