### PR TITLE
Refactor overlay.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,11 +149,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1609372815,
-        "narHash": "sha256-lD9HDjEs6KvszvpmrsbRyokiFLry3xijGujlfusYSZo=",
+        "lastModified": 1609431445,
+        "narHash": "sha256-2BoWYXSUOacFVsy+5NUBSxselTmGVqdRv3JZidj1hbw=",
         "owner": "hackworthltd",
         "repo": "hacknix-lib",
-        "rev": "ba888b19a0b7d493ba082d3efa5e4aea085e2af6",
+        "rev": "3df43ca5e302e8ab7b16239c2a9fc42182830593",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
We flatten it and include all the overlay dependencies, as well. This
is much easier to deal with downstream.