### PR TITLE
Switch nixpkgs to upstream.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Hackworth Ltd's nixpkgs overlays and NixOS modules.";
 
   inputs = {
-    nixpkgs.url = github:hackworthltd/nixpkgs/big-sur-fixes-v4;
+    nixpkgs.url = github:NixOS/nixpkgs;
 
     nix-darwin.url = github:LnL7/nix-darwin;
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
@@ -160,10 +160,6 @@
               # inherit (pkgs) gitignoreSource gitignoreFilter;
               # inherit (pkgs) hashedCertDir;
               # inherit (pkgs) lib;
-
-              # Build these overrides (for Big Sur support) until
-              # they're upstreamed.
-              inherit (pkgs) python38 python39;
             }) //
           # For some reason, the filterPackagesByPlatform doesn't
           # filter these Linux kernels from the macOS package set, so


### PR DESCRIPTION
Python 3.8.7 was finally merged, so hopefully this fixes all remaining
Big Sur issues and we can deprecate our fork.

(Note that Python 3.8.7 isn't on nixpkgs-unstable yet, so we're using
the upstream trunk here until nixpkgs-unstable catches up.)