### PR TITLE
Patch Hydra so that it ignores git submodule failures.

### DIFF
--- a/nix/overlays/100-hydra.nix
+++ b/nix/overlays/100-hydra.nix
@@ -16,6 +16,10 @@ let
         # Enable verbose mode in hydra-eval-jobs so that we can see
         # some semblance of progress in the logs.
         ../patches/hydra/verbose-hydra-eval-jobs.patch
+
+        # We have some git repos with private submodules. Allow Hydra
+        # to continue evaluating when it can't check these out.
+        ../patches/hydra/ignore-submodule-failures.patch
       ];
     }
   );

--- a/nix/patches/hydra/ignore-submodule-failures.patch
+++ b/nix/patches/hydra/ignore-submodule-failures.patch
@@ -1,0 +1,19 @@
+diff --git a/src/script/nix-prefetch-git b/src/script/nix-prefetch-git
+index 3fe399c8..fd10c18a 100755
+--- a/src/script/nix-prefetch-git
++++ b/src/script/nix-prefetch-git
+@@ -136,11 +136,11 @@ checkout_ref(){
+ # Update submodules
+ init_submodules(){
+     # Add urls into .git/config file
+-    git submodule init
++    git submodule init || echo "WARNING: git submodule init failed" >&2
+ 
+     # list submodule directories and their hashes
+-    git submodule update
+-    git submodule status
++    git submodule update || echo "WARNING: git submodule update failed" >&2
++    git submodule status || echo "WARNING: git submodule status failed" >&2
+ }
+ 
+ clone(){


### PR DESCRIPTION
We have some git repos with private submodules. These submodules
contain secrets for deployment, but aren't needed by the Hydra in
order to evaluate the project and build its derivations.

The included patch will print a warning when submodules can't be
fetched, but the Hydra will keep going anyway.