### PR TITLE
Bump dependencies and fix Hydra nixpkgs input.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     "badhosts": {
       "flake": false,
       "locked": {
-        "lastModified": 1611415393,
-        "narHash": "sha256-Cpj9cph28u6V0ASYQUBQCd5iw8dW05sklP7wm9UzjeI=",
+        "lastModified": 1611451135,
+        "narHash": "sha256-OqkC3pijSIcud+18XBKF2V1ScUW709dpl7+LdQQc1kY=",
         "owner": "StevenBlack",
         "repo": "hosts",
-        "rev": "642e3d1b6a9363caa88402b86464cab1b0136fb4",
+        "rev": "7ac09a4f4df2d325c4b0a7b6443fddd878f4d796",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1611432849,
-        "narHash": "sha256-MNDArueUkfsiGdz3/9NqHs2QNZ7yH/DUSiGLNQTBfKU=",
+        "lastModified": 1611491037,
+        "narHash": "sha256-D8JqxVqA3DoKQ4FFxAvpqU7KXGYWlZtfob6cPQv16AQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0860cb667775d4f32ccd81de5606d1f7ced5f7f1",
+        "rev": "cd9550fda22ea8040b1703168715bdf4e889f9c3",
         "type": "github"
       },
       "original": {
@@ -149,11 +149,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1611404401,
-        "narHash": "sha256-rtJGFCOvsgJ+sqlQIuP30iGgviO/0lHSPpRfVDGHdiE=",
+        "lastModified": 1611489648,
+        "narHash": "sha256-s+tBaS7UKasA8JXmuT+YqJ9QUkIFqjB1Kgy9OyERBCo=",
         "owner": "hackworthltd",
         "repo": "hacknix-lib",
-        "rev": "ee407c09b370324ea7914ced2bd227b57ad7eb1c",
+        "rev": "82453977b00ccdbe921620f0884a899f375bd7ef",
         "type": "github"
       },
       "original": {
@@ -166,8 +166,6 @@
       "inputs": {
         "nix": "nix",
         "nixpkgs": [
-          "hydra",
-          "nix",
           "nixpkgs"
         ]
       },
@@ -261,11 +259,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1611278258,
-        "narHash": "sha256-dmNK5TaFHyCqM4XEwRJl6adZ0Y4ZdnV12YztvPm1B14=",
+        "lastModified": 1611396451,
+        "narHash": "sha256-ZQDpSOA8NAu4Gzoen0lNtjxHB0GY1VJAC/cByOAvpb8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd0daed2e8d590418fc565de70ea6ca47a6d2dcb",
+        "rev": "f6a583eeece936a1d917de67194fec4b6c74cf1f",
         "type": "github"
       },
       "original": {
@@ -292,11 +290,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1611396451,
-        "narHash": "sha256-ZQDpSOA8NAu4Gzoen0lNtjxHB0GY1VJAC/cByOAvpb8=",
+        "lastModified": 1611429538,
+        "narHash": "sha256-5xlIMueskuOBYckggcZj6TyBxrQ5OhwaZNgCH1Zq6zU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f6a583eeece936a1d917de67194fec4b6c74cf1f",
+        "rev": "fcef64cc39816a38a0c617a7e49076fc1ab080cf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
     gitignore-nix.flake = false;
 
     hydra.url = github:NixOS/hydra;
+    hydra.inputs.nixpkgs.follows = "nixpkgs";
 
     traefik-forward-auth.url = github:thomseddon/traefik-forward-auth;
     traefik-forward-auth.flake = false;


### PR DESCRIPTION
This should prevent downstream users of this flake from needing to
specify the hydra nixpkgs input pin.