### PR TITLE
virtual-ips: set useDHCP to false.

### DIFF
--- a/nix/modules/networking/virtual-ips/default.nix
+++ b/nix/modules/networking/virtual-ips/default.nix
@@ -47,20 +47,23 @@ in
   config = lib.mkIf enabled {
     boot.kernelModules = [ "dummy" ];
     networking.interfaces."${cfg.interface}" = {
+      useDHCP = false;
       ipv4.addresses = map
         (
           address: {
             inherit address;
             prefixLength = 32;
           }
-        ) cfg.v4;
+        )
+        cfg.v4;
       ipv6.addresses = map
         (
           address: {
             inherit address;
             prefixLength = 128;
           }
-        ) cfg.v6;
+        )
+        cfg.v6;
     };
   };
 }


### PR DESCRIPTION
Previously this hasn't been necessary, but it appears that, if
enabling virtual IPs on a system where the default was to set `useDHCP
= true` on all interfaces, then the virtual-ip service will time out
waiting for a DHCP response that will never come!