### PR TITLE
Update chamber to use most recent AWS Go SDK.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,37 +1,5 @@
 {
   "nodes": {
-    "aws-export-credentials": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1610462124,
-        "narHash": "sha256-kuWL2EpcQKOGaj4idLA/JQNSKHqqa82P3xiKZdoqe9w=",
-        "owner": "benkehoe",
-        "repo": "aws-export-credentials",
-        "rev": "967c0e5bc4db27f08446e15a14fadd8feb5ad0e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "benkehoe",
-        "repo": "aws-export-credentials",
-        "type": "github"
-      }
-    },
-    "aws-sso-credential-process": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1605057290,
-        "narHash": "sha256-uYdlk3LcdEJCZb0lQWh8ZzgnWhSNlFftwdds+uyQ5RA=",
-        "owner": "benkehoe",
-        "repo": "aws-sso-credential-process",
-        "rev": "3a59c030c820a6faa23adb1454c036fd3d929e8f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "benkehoe",
-        "repo": "aws-sso-credential-process",
-        "type": "github"
-      }
-    },
     "badhosts": {
       "flake": false,
       "locked": {
@@ -51,15 +19,16 @@
     "chamber": {
       "flake": false,
       "locked": {
-        "lastModified": 1602373352,
-        "narHash": "sha256-n1VmBFk9AY7LZXUsvHIQUScpHk52RtkIMi3cW4RKA8Y=",
+        "lastModified": 1613841193,
+        "narHash": "sha256-y/eiba730E6tSA3OxQAHNFaUVknP5sZxMsX2xj4TaOU=",
         "owner": "hackworthltd",
         "repo": "chamber",
-        "rev": "7c5297b63fe63fa49b7e70dd2de0c32adacb0de1",
+        "rev": "a07d4ab905659fc0080b751b8ccca7dce7c3bab7",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
+        "ref": "aws-sdk-go-v1.37.15",
         "repo": "chamber",
         "type": "github"
       }
@@ -306,8 +275,6 @@
     },
     "root": {
       "inputs": {
-        "aws-export-credentials": "aws-export-credentials",
-        "aws-sso-credential-process": "aws-sso-credential-process",
         "badhosts": "badhosts",
         "chamber": "chamber",
         "emacs-overlay": "emacs-overlay",

--- a/flake.nix
+++ b/flake.nix
@@ -18,16 +18,10 @@
 
     hacknix-lib.url = github:hackworthltd/hacknix-lib;
 
-    aws-export-credentials.url = github:benkehoe/aws-export-credentials;
-    aws-export-credentials.flake = false;
-
-    aws-sso-credential-process.url = github:benkehoe/aws-sso-credential-process;
-    aws-sso-credential-process.flake = false;
-
     badhosts.url = github:StevenBlack/hosts;
     badhosts.flake = false;
 
-    chamber.url = github:hackworthltd/chamber;
+    chamber.url = github:hackworthltd/chamber/aws-sdk-go-v1.37.15;
     chamber.flake = false;
 
     emacs-overlay.url = github:nix-community/emacs-overlay;
@@ -114,8 +108,6 @@
           (hacknix-lib.lib.flakes.filterPackagesByPlatform system
             {
               inherit (pkgs) awscli2;
-              inherit (pkgs) aws-export-credentials;
-              inherit (pkgs) aws-sso-credential-process;
 
               inherit (pkgs) badhosts-unified;
               inherit (pkgs)

--- a/nix/overlays/100-aws.nix
+++ b/nix/overlays/100-aws.nix
@@ -2,18 +2,7 @@ final: prev:
 let
   # Upstream keeps breaking this and it's usually not up-to-date, either.
   awscli2 = final.callPackage ../pkgs/awscli2 { };
-
-  aws-export-credentials = final.callPackage ../pkgs/aws-export-credentials {
-    src = final.lib.hacknix.flake.inputs.aws-export-credentials;
-  };
-
-  aws-sso-credential-process = final.callPackage ../pkgs/aws-sso-credential-process {
-    src = final.lib.hacknix.flake.inputs.aws-sso-credential-process;
-  };
-
 in
 {
   inherit awscli2;
-  inherit aws-export-credentials;
-  inherit aws-sso-credential-process;
 }

--- a/nix/pkgs/awscli2/default.nix
+++ b/nix/pkgs/awscli2/default.nix
@@ -7,22 +7,13 @@
 let
   py = python3.override {
     packageOverrides = self: super: {
-      botocore = super.botocore.overridePythonAttrs
-        (oldAttrs: rec {
-          version = "2.0.0dev71";
-          src = fetchFromGitHub
-            {
-              owner = "boto";
-              repo = "botocore";
-              rev = "f8b31e2a01a8797f8331c6af2c93a26ff82b2b4b";
-              sha256 = "0dzi92gzbprjapp4kmcy9y6m8ir92lan76frmfjr2pjghkmrb5fv";
-            };
-        });
-      colorama = super.colorama.overridePythonAttrs (oldAttrs: rec {
-        version = "0.4.3";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "189n8hpijy14jfan4ha9f5n06mnl33cxz7ay92wjqgkr639s0vg9";
+      botocore = super.botocore.overridePythonAttrs (oldAttrs: rec {
+        version = "2.0.0dev93";
+        src = fetchFromGitHub {
+          owner = "boto";
+          repo = "botocore";
+          rev = "2d3d78b759341fe25a3b232bbca29b20c8ec61fd";
+          sha256 = "sha256-pTLrsON4QdtULwWNBQ5TREtOS97hg1XQZpgwjfq0nwg=";
         };
       });
       prompt_toolkit = super.prompt_toolkit.overridePythonAttrs (oldAttrs: rec {
@@ -38,16 +29,17 @@ let
 in
 with py.pkgs; buildPythonApplication rec {
   pname = "awscli2";
-  version = "2.1.3"; # N.B: if you change this, change botocore to a matching version too
+  version = "2.1.25"; # N.B: if you change this, change botocore to a matching version too
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-cli";
     rev = version;
-    sha256 = "0pfiyczjldsvz0f041n09gbp0ivm4nxr5jp8r26dd9nd6br4qjgf";
+    sha256 = "sha256-2H9W1ibcP1vw+1NASJnL2f02G3CyPWovm5AAXHArbkU=";
   };
 
   postPatch = ''
+    substituteInPlace setup.py --replace "colorama>=0.2.5,<0.4.4" "colorama>=0.2.5"
     substituteInPlace setup.py --replace "cryptography>=2.8.0,<=2.9.0" "cryptography>=2.8.0"
     substituteInPlace setup.py --replace "docutils>=0.10,<0.16" "docutils>=0.10"
     substituteInPlace setup.py --replace "ruamel.yaml>=0.15.0,<0.16.0" "ruamel.yaml>=0.15.0"
@@ -76,10 +68,15 @@ with py.pkgs; buildPythonApplication rec {
   ];
 
   postInstall = ''
-    mkdir -p $out/etc/bash_completion.d
-    echo "complete -C $out/bin/aws_completer aws" > $out/etc/bash_completion.d/awscli
+    mkdir -p $out/${python3.sitePackages}/awscli/data
+    ${python3.interpreter} scripts/gen-ac-index --index-location $out/${python3.sitePackages}/awscli/data/ac.index
+
+    mkdir -p $out/share/bash-completion/completions
+    echo "complete -C $out/bin/aws_completer aws" > $out/share/bash-completion/completions/aws
+
     mkdir -p $out/share/zsh/site-functions
     mv $out/bin/aws_zsh_completer.sh $out/share/zsh/site-functions
+
     rm $out/bin/aws.cmd
   '';
 

--- a/nix/pkgs/chamber/default.nix
+++ b/nix/pkgs/chamber/default.nix
@@ -9,10 +9,10 @@ let
 in
 buildGoModule rec {
   pname = "chamber";
-  version = "2.8.2";
+  version = "2.9.1";
 
   deleteVendor = true;
-  vendorSha256 = "05lipdkrr3v64ppj13gp48zfk0w946qfpavg6w2y591az4pyx7zl";
+  vendorSha256 = "sha256-bXliUugkvS+dIo4BecvjjK7QSVFm90tNjcQFD8OJ2x8=";
 
   inherit src;
 


### PR DESCRIPTION
This version of the AWS Go SDK includes support for SSO, so we
shouldn't need aws-sso-credential-process anymore.

Also drop our old version of awscli2 as upstream now has a more recent
one.