### PR TITLE
Disable amazon-init service the "proper" way.

### DIFF
--- a/nix/modules/config/providers/ec2/default.nix
+++ b/nix/modules/config/providers/ec2/default.nix
@@ -22,6 +22,6 @@ in
 
   config = lib.mkIf cfg.enable {
     ec2.hvm = true;
-    systemd.services.amazon-init.wantedBy = pkgs.lib.mkForce [ ];
+    virtualisation.amazon-init = false;
   };
 }


### PR DESCRIPTION
I believe it used to be the case that this could only be disabled by
reaching into the services.amazon-init attributes, but now there's an
official way to disable it.