### PR TITLE
Revert nixpkgs version to fix a Nix issue.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1621014849,
-        "narHash": "sha256-p7Ko6UxP81oMA7cEAGkOKsERX5DNNc6GOEXTVK70LNs=",
+        "lastModified": 1621072981,
+        "narHash": "sha256-YkM+NSFX8e6WBcou+Or2wit6eBVK+poLGjGJu9iGE84=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "03ad7e2ee98b3d8f76d3206f541ce7779de48d17",
+        "rev": "7320af085d29058bd39657ad6cc78c08e53b3174",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1620999993,
-        "narHash": "sha256-X2lYtA8Ns4bIejtD3BtfAkaTs1dpskCXPZBbfIaaPhs=",
+        "lastModified": 1621069684,
+        "narHash": "sha256-ui02CzdCsi/2pS/yy4XZCh7sjXMQJgxZ26SmoQoGCrM=",
         "owner": "hackworthltd",
         "repo": "hacknix-lib",
-        "rev": "edeaaa5eb02185a5b5160129210e7cda36dc8de3",
+        "rev": "8483cef6d3c728b9c283153bbae16f72bb43eb7f",
         "type": "github"
       },
       "original": {
@@ -172,17 +172,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1620995888,
-        "narHash": "sha256-B4Q3c6IvTLg3Q92qYa8y+i4uTaphtFdjp+Ir3QQjdN0=",
+        "lastModified": 1619973265,
+        "narHash": "sha256-EgdfNdqrv/r1s70KGti4r6Bkdg3hs1BuqzQzxraq9JU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94b2848559b12a8ed1fe433084686b2a81123c99",
+        "rev": "9775b39fd45a61c2a53aa6a90485fac8f87ce7c6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "9775b39fd45a61c2a53aa6a90485fac8f87ce7c6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Hackworth Ltd's nixpkgs overlays and NixOS modules.";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
+    nixpkgs.url = github:NixOS/nixpkgs/9775b39fd45a61c2a53aa6a90485fac8f87ce7c6;
     hacknix-lib.url = github:hackworthltd/hacknix-lib;
     hacknix-lib.inputs.nixpkgs.follows = "nixpkgs";
 

--- a/nix/modules/dns/unbound-multi-instance/default.nix
+++ b/nix/modules/dns/unbound-multi-instance/default.nix
@@ -224,7 +224,7 @@ in
     # them here.
 
     hacknix.assertions.moduleHashes."services/networking/unbound.nix" =
-      "dae90e6841a2b41eeb4a0b3c25739b04dbb135417793116465324a2050632a21";
+      "8213eb3b5b513e41d970d300608a93b49bd993595f83fbfc9df59099be202566";
 
     environment.systemPackages = [ pkgs.unbound ];
 

--- a/nix/modules/email/null-client/default.nix
+++ b/nix/modules/email/null-client/default.nix
@@ -91,7 +91,7 @@ in
   config = mkIf enabled {
 
     hacknix.assertions.moduleHashes."services/mail/postfix.nix" =
-      "a7961dc45da9d7f60c50bbfc79aa244ff08a719c8ddea50353b632dd547a37c9";
+      "266bb18861ff1e33a60882758679ea0911c9d09bf81e4af7ae0f6cac71a467b7";
 
     services.postfix = {
       enable = true;

--- a/nix/modules/email/postfix-mta/default.nix
+++ b/nix/modules/email/postfix-mta/default.nix
@@ -611,7 +611,7 @@ in
   config = mkIf enabled {
 
     hacknix.assertions.moduleHashes."services/mail/postfix.nix" =
-      "a7961dc45da9d7f60c50bbfc79aa244ff08a719c8ddea50353b632dd547a37c9";
+      "266bb18861ff1e33a60882758679ea0911c9d09bf81e4af7ae0f6cac71a467b7";
     hacknix.assertions.moduleHashes."security/acme.nix" =
       "7da4b012025b208e65e5c26da09518e6d0c4b768fc3e7298dde93ef3c91114ff";
 

--- a/nix/modules/email/relay-host/default.nix
+++ b/nix/modules/email/relay-host/default.nix
@@ -188,7 +188,7 @@ in
   config = mkIf enabled {
 
     hacknix.assertions.moduleHashes."services/mail/postfix.nix" =
-      "a7961dc45da9d7f60c50bbfc79aa244ff08a719c8ddea50353b632dd547a37c9";
+      "266bb18861ff1e33a60882758679ea0911c9d09bf81e4af7ae0f6cac71a467b7";
 
     assertions = [
       {


### PR DESCRIPTION
Nix is majorly broken since
https://github.com/NixOS/nixpkgs/commit/946cc38f70a7dbea5d2c4bbeb4021b43beb3b3ce

Hopefully this is fixed by
https://github.com/NixOS/nixpkgs/commit/5e7e70b2004f58d852730c91ad9b0a0833d902f1
but until that's in nixpkgs-unstable, we'll revert to the last
nixpkgs-unstable before the breaking change.