### PR TITLE
Bump dependencies & assign remote-builder user to its own group.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "emacs-overlay": {
       "locked": {
-        "lastModified": 1631467754,
-        "narHash": "sha256-lZbeo1Y/jni/KW1W+DnaeCPgIu+W+ks8qp3xlRtUYFQ=",
+        "lastModified": 1631757539,
+        "narHash": "sha256-lFY2oPAnXl0OuvyeTlrt0LJBdIbJ0GtzJYee/LicrDg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e00f171142307b3c9bb962beeaaf09d0254f9e31",
+        "rev": "a5c191fec66e3f8a8f192a394af763c7dc7ea43b",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1631315520,
-        "narHash": "sha256-Y8j0JYtZMifrHaWdTfTp1mYVXZ2PLJO/P0XZxMvo7KU=",
+        "lastModified": 1631725679,
+        "narHash": "sha256-EXFxVj4rN3IN8o6OSipUH2JczePbRkkUvF+ZMan9xm4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b72ad04a8a324697d3fb92e19cd840379a902813",
+        "rev": "2bb5cbf7f8b99a8d1d6646abe5ab993f6823212f",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1630255023,
-        "narHash": "sha256-uCnRUM2qhlEXSbJsY4PkES49WFTWdFhcNc1vwbec/1Y=",
+        "lastModified": 1631599548,
+        "narHash": "sha256-IE83PrNQTLYL1N99P+Ts/58rSWlT0IH1zdhQQpx7e00=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3e4ebc851c91d1ce5c65da23436726c555a0d7e8",
+        "rev": "32d94573f7d8fe2c8c7874140990d0f49ea9d344",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     "spago2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1628161480,
-        "narHash": "sha256-oTBdCpCJmuMQ6nYR1+tamL9xDPm720dRVxsKtKOzTfs=",
+        "lastModified": 1631778242,
+        "narHash": "sha256-Beyls5A0aVNTeIQmk3bfq/KS0paK6xPtvC6syEeVZjM=",
         "owner": "justinwoo",
         "repo": "spago2nix",
-        "rev": "da4a833b53f9139e596f89ad89d892f4f60fc179",
+        "rev": "874efd1d8e25521463d3f6e60493e629f2ab1cd5",
         "type": "github"
       },
       "original": {

--- a/nix/modules/config/remote-builds/remote-build-host/default.nix
+++ b/nix/modules/config/remote-builds/remote-build-host/default.nix
@@ -83,7 +83,9 @@ in
       description = "Nix remote builder";
       openssh.authorizedKeys.keys = authorizedKeys;
       isSystemUser = true;
+      group = "${cfg.user.name}";
     };
+    users.groups."${cfg.user.name}" = { };
 
     # Useful utilities.
     environment.systemPackages = with pkgs; [ htop glances ];


### PR DESCRIPTION
Upstream nixpkgs now shows this warning:

```
       Failed assertions:
       - users.users.remote-builder.group is unset. This used to default to
       nogroup, but this is unsafe. For example you can create a group
       for this user with:
       users.users.remote-builder.group = "remote-builder";
       users.groups.remote-builder = {};
```