### PR TITLE
nixUnstable: workaround macOS breakage until upstream fix is merged.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -245,6 +245,7 @@
           inherit (pkgs) fsatrace;
           inherit (pkgs) hostapd;
           inherit (pkgs) libprelude;
+          inherit (pkgs) nixUnstable;
           inherit (pkgs) nmrpflash;
           inherit (pkgs) purescript_0_13_8;
           inherit (pkgs) spago2nix;

--- a/nix/overlays/140-nix.nix
+++ b/nix/overlays/140-nix.nix
@@ -1,0 +1,13 @@
+final: prev:
+let
+
+  # https://github.com/NixOS/nixpkgs/pull/138186
+  # https://github.com/nix-community/nix-direnv/issues/113
+  nixUnstable = prev.nixUnstable.override {
+    patches = [ ../patches/nix/unset-is-macho.patch ];
+  };
+
+in
+{
+  inherit nixUnstable;
+}

--- a/nix/patches/nix/unset-is-macho.patch
+++ b/nix/patches/nix/unset-is-macho.patch
@@ -1,0 +1,13 @@
+diff --git a/src/nix/get-env.sh b/src/nix/get-env.sh
+index 42c806450..a8563c772 100644
+--- a/src/nix/get-env.sh
++++ b/src/nix/get-env.sh
+@@ -8,6 +8,8 @@ if [[ -n $stdenv ]]; then
+     source $stdenv/setup
+ fi
+ 
++unset -f isMachO
++
+ # Better to use compgen, but stdenv bash doesn't have it.
+ __vars="$(declare -p)"
+ __functions="$(declare -F)"


### PR DESCRIPTION
See:
https://github.com/NixOS/nixpkgs/pull/138186