### PR TITLE
chore(nix): Bump dependencies.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,27 +105,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1635368700,
-        "narHash": "sha256-WM3skaKXN+Pz8QmrJBj1LWqDtMLIDyCrJmoMxg5riCc=",
+        "lastModified": 1636917388,
+        "narHash": "sha256-Htsbqwr6XuVeASq9n96RKWxPMEuvPPoLd6rRtGyBGCs=",
         "owner": "hackworthltd",
         "repo": "nix-darwin",
-        "rev": "6da0244e807690a46e600a59cec79f5a6d1217b9",
+        "rev": "73079ea91aa2bd5c97f39e12aa4eb329d791b284",
         "type": "github"
       },
       "original": {
         "owner": "hackworthltd",
-        "ref": "fixes-v10",
+        "ref": "fixes-v12",
         "repo": "nix-darwin",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636827220,
-        "narHash": "sha256-1TE4YoVvd3C9/+0t/oxBeoTz9tXhHDtcGUIPITB2b4E=",
+        "lastModified": 1636886446,
+        "narHash": "sha256-4xsVM2H8CG3d/3V+GqDDLDOmb3kdrugbqKVyrg8Q/zc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf6b299a38ad35f5f436001eac51d6a964a9e53d",
+        "rev": "5cb226a06c49f7a2d02863d0b5786a310599df6b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
-    nix-darwin.url = github:hackworthltd/nix-darwin/fixes-v10;
+    nix-darwin.url = github:hackworthltd/nix-darwin/fixes-v12;
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     arion-flake.url = github:hercules-ci/arion;

--- a/nix/darwinModules/config/defaults/default.nix
+++ b/nix/darwinModules/config/defaults/default.nix
@@ -27,10 +27,6 @@ in
     nixpkgs.config.allowUnfree = true;
     nixpkgs.config.allowBroken = true;
 
-    # Workaround until this is fixed:
-    # https://github.com/LnL7/nix-darwin/issues/373
-    nix.package = pkgs.nixUnstable;
-
     nix.trustedUsers = [ "@admin" ];
 
     # See https://gist.github.com/LnL7/1cfca66d17eba1f9936175926bf39de8.


### PR DESCRIPTION
Also, remove the workaround for
https://github.com/LnL7/nix-darwin/issues/373 as our nix-darwin fork
now has a patch for it (see
https://github.com/LnL7/nix-darwin/pull/379).

Note that this nix-darwin rev also removes the `nixUnstable` hacks we
were using previously so that we could use `nixStable` as the system
version, but `nixUnstable` for flakes support in the user's
environment and for `darwin-rebuild`. `nixStable` is now 2.4, so it
should be safe to use it for all scenarios we want to support.