### PR TITLE
unbound-multi-insance: Quote literalExpression

### DIFF
--- a/nix/modules/dns/unbound-multi-instance/default.nix
+++ b/nix/modules/dns/unbound-multi-instance/default.nix
@@ -114,14 +114,14 @@ in
         Zero or more Unbound service instances.
       '';
       default = { };
-      example = literalExpression {
+      example = literalExpression ''
         adblock = {
           allowedAccess = [ "10.0.0.0/8" ];
           listenAddresses = [ "10.8.8.8" "2001:db8::1" ];
           extraConfig =
             builtins.readFile ./badhosts.conf;
         };
-      };
+      '';
       type = types.attrsOf
         (
           types.submodule {


### PR DESCRIPTION
In case you want to render docs, the string becomes the example, verbatim.

Not sure what happens if you don't put a string there.

Found while debugging a large derivations bug in Nix.