### PR TITLE
fix: Add a `login` to netrc credentials.

### DIFF
--- a/examples/nix-darwin/build-host.nix
+++ b/examples/nix-darwin/build-host.nix
@@ -67,6 +67,7 @@
         credentials = {
           hackworthltd = {
             vaultPath = "secret/cachix/hackworthltd";
+            login = "dhess";
             hostname = "hackworthltd.cachix.org";
           };
         };

--- a/examples/nixos/build-host.nix
+++ b/examples/nixos/build-host.nix
@@ -80,6 +80,7 @@
           credentials = {
             hackworthltd = {
               vaultPath = "secret/cachix/hackworthltd";
+              login = "dhess";
               hostname = "hackworthltd.cachix.org";
             };
           };

--- a/nix/common/config/services/vault/agent/template/netrc/default.nix
+++ b/nix/common/config/services/vault/agent/template/netrc/default.nix
@@ -12,7 +12,7 @@ let
 
   templateContents = app: lib.concatMapStrings
     (creds: ''
-      machine ${creds.hostname} password {{ with secret "${creds.vaultPath}" }}{{ .Data.data.token }}{{ end }}
+      machine ${creds.hostname} login ${creds.login} password {{ with secret "${creds.vaultPath}" }}{{ .Data.data.token }}{{ end }}
     ''
     )
     (lib.mapAttrsToList (_: creds: creds) app.credentials);
@@ -61,6 +61,15 @@ let
           <literal>netrc</literal> credentials. Note that the
           password/token must be stored in a key/value pair whose key
           is named <literal>token</literal>.
+        '';
+      };
+
+      login = lib.mkOption {
+        type = pkgs.lib.types.nonEmptyStr;
+        example = "alice";
+        description = ''
+          The login name for these credentials. Note that some clients
+          may ignore this field, in which case you can use a nonce.
         '';
       };
 


### PR DESCRIPTION
We've been using this Vault Agent template for Cachix, and it has
worked fine until recently, when we started having issues using a
private Cachix cache. The issue appears to be related to

https://github.com/cachix/cachix/issues/406

which is worked around by adding a nonce login name. Furthermore, it's
likely that other netrc clients will need the login, so we now require
it.