### PR TITLE
ci: switch to circuithub/nix-buildkite.

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,7 @@ steps:
   - command: nix-buildkite
     label: ":nixos: :buildkite:"
     plugins:
-      - hackworthltd/nix-buildkite#hackworthltd-v5:
+      - circuithub/nix-buildkite:
           file: nix/ci.nix
           post-build-hook:
             /run/current-system/sw/bin/buildkite-public-post-build-hook


### PR DESCRIPTION
All our patches are now upstream.