### PR TITLE
refactor(nix)!: Switch to flake-parts.

### DIFF
--- a/examples/nixos/build-host.nix
+++ b/examples/nixos/build-host.nix
@@ -1,6 +1,7 @@
 args:
 
 args // {
+  system = "x86_64-linux";
   modules = [
     ({ pkgs, ... }:
       let

--- a/examples/nixos/remote-build-host.nix
+++ b/examples/nixos/remote-build-host.nix
@@ -1,5 +1,6 @@
 args:
 args // {
+  system = "x86_64-linux";
   modules = [
     ({ pkgs, ... }:
       let

--- a/flake.lock
+++ b/flake.lock
@@ -32,6 +32,24 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1673362319,
+        "narHash": "sha256-Pjp45Vnj7S/b3BRpZEVfdu8sqqA6nvVjvYu59okhOyI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "82c16f1682cf50c01cb0280b38a1eed202b3fe9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -152,6 +170,24 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1672350804,
+        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1673800717,
@@ -203,9 +239,7 @@
     "pre-commit-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": [
-          "flake-utils"
-        ],
+        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -229,7 +263,7 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "gitignore-nix": "gitignore-nix",
         "nix-darwin": "nix-darwin",
         "nixos-generators": "nixos-generators",

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,9 @@
 {
-  description = "Hackworth Ltd's nixpkgs overlays and NixOS modules.";
+  description = "Hackworth Ltd Nix.";
 
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
     nix-darwin.url = github:LnL7/nix-darwin;
-
-    flake-utils.url = github:numtide/flake-utils;
 
     flake-compat.url = github:edolstra/flake-compat;
     flake-compat.flake = false;
@@ -21,398 +19,331 @@
 
     pre-commit-hooks-nix.url = github:cachix/pre-commit-hooks.nix;
     pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
-    # Fixes aarch64-darwin support.
-    pre-commit-hooks-nix.inputs.flake-utils.follows = "flake-utils";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs =
-    { self
-    , flake-utils
-    , nixpkgs
-    , nix-darwin
-    , sops-nix
-    , nixos-generators
-    , pre-commit-hooks-nix
-    , ...
-    }@inputs:
+  outputs = inputs@ { flake-parts, ... }:
     let
-      bootstrap = (import ./nix/overlays/000-bootstrap.nix) { } nixpkgs;
-
-      supportedSystems = [
-        "x86_64-linux"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
-      forAllSupportedSystems = flake-utils.lib.eachSystem supportedSystems;
-
-      linuxCISystems = [
-        "x86_64-linux"
-        "aarch64-linux"
-      ];
-      forAllLinuxCISystems = flake-utils.lib.eachSystem linuxCISystems;
-
-      macCISystems = [ "aarch64-darwin" ];
-      forAllMacCISystems = flake-utils.lib.eachSystem macCISystems;
-
-      pkgsFor = system: import nixpkgs
-        {
-          inherit system;
-          config = {
-            allowUnfree = true;
-            allowBroken = true;
-          };
-          overlays = [ self.overlay ];
-        };
-
-      lib = (pkgsFor "x86_64-linux").lib;
-
     in
-    {
-      inherit lib;
+    flake-parts.lib.mkFlake { inherit inputs; }
+      {
+        debug = true;
 
-      overlay =
-        let
-          overlaysFromDir = bootstrap.lib.overlays.combineFromDir ./nix/overlays;
-        in
-        bootstrap.lib.overlays.combine [
-          (final: prev: {
-            lib = (prev.lib or { }) // {
+        imports = [
+          inputs.pre-commit-hooks-nix.flakeModule
+        ];
+        systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
 
-              flakes = (prev.lib.flakes or { }) // {
-                # For some reason, the nixpkgs flake doesn't roll its local
-                # lib.nixosSystem into nixpkgs.lib. We expose it here.
-                inherit (nixpkgs.lib) nixosSystem;
-
-                # Ditto for nix-darwin's lib.darwinSystem function.
-                inherit (nix-darwin.lib) darwinSystem;
-
-                inherit (nixos-generators) nixosGenerate;
+        perSystem = { config, pkgs, system, ... }: {
+          # We need a `pkgs` that includes our own overlays within
+          # `perSystem`. This isn't done by default, so we do this
+          # workaround. See:
+          #
+          # https://github.com/hercules-ci/flake-parts/issues/106#issuecomment-1399041045
+          _module.args.pkgs = import inputs.nixpkgs
+            {
+              inherit system;
+              config = {
+                allowUnfree = true;
+                allowBroken = true;
               };
+              overlays = [ inputs.self.overlays.default ];
+            };
 
-              hacknix = (prev.lib.hacknix or { }) // {
-                flake = (prev.lib.hacknix.flake or { }) // {
-                  inherit inputs;
-                  inherit (self) darwinModule;
-                  inherit (self) nixosModule;
+          pre-commit = {
+            check.enable = true;
+            settings = {
+              src = ./.;
+              hooks = {
+                nixpkgs-fmt.enable = true;
+
+                prettier = {
+                  enable = true;
+                  excludes = [ ".github/" ];
+                };
+
+                actionlint = {
+                  enable = true;
+                  name = "actionlint";
+                  entry = "${pkgs.actionlint}/bin/actionlint";
+                  language = "system";
+                  files = "^.github/workflows/";
                 };
               };
+
+              excludes = [
+                "CODE_OF_CONDUCT.md"
+                "LICENSE"
+                ".mergify.yml"
+                ".buildkite/"
+              ];
             };
-          })
-          sops-nix.overlay
-          overlaysFromDir
-        ];
-
-      # Ideally, this would be refactored into multiple stand-alone
-      # modules, but many of these modules are interdependent at the
-      # moment, so we simply export them as a single module, for now.
-      nixosModule = {
-        imports = [
-          ./nix/modules/config/providers/ec2/default.nix
-          ./nix/modules/config/providers/linode/default.nix
-          ./nix/modules/config/providers/vultr/cloud/default.nix
-
-          ./nix/modules/config/defaults/default.nix
-          ./nix/modules/config/defaults/acme.nix
-          ./nix/modules/config/defaults/environment.nix
-          ./nix/modules/config/defaults/networking.nix
-          ./nix/modules/config/defaults/nginx.nix
-          ./nix/modules/config/defaults/nix.nix
-          ./nix/modules/config/defaults/security.nix
-          ./nix/modules/config/defaults/ssh.nix
-          ./nix/modules/config/defaults/sudo.nix
-          ./nix/modules/config/defaults/system.nix
-          ./nix/modules/config/defaults/tmux.nix
-          ./nix/modules/config/defaults/users.nix
-
-          ./nix/modules/config/services/freeradius
-
-          ./nix/modules/config/hardware/amd/common.nix
-          ./nix/modules/config/hardware/amd/jaguar.nix
-          ./nix/modules/config/hardware/apu2/apu3c4.nix
-          ./nix/modules/config/hardware/intel/broadwell-de.nix
-          ./nix/modules/config/hardware/intel/centerton.nix
-          ./nix/modules/config/hardware/intel/coffee-lake.nix
-          ./nix/modules/config/hardware/intel/common.nix
-          ./nix/modules/config/hardware/intel/haswell.nix
-          ./nix/modules/config/hardware/intel/kaby-lake.nix
-          ./nix/modules/config/hardware/intel/sandy-bridge.nix
-          ./nix/modules/config/hardware/smartd/1x-non-removable.nix
-          ./nix/modules/config/hardware/smartd/2x-non-removable.nix
-          ./nix/modules/config/hardware/smartd/36x-hotswap.nix
-          ./nix/modules/config/hardware/smartd/4x-hotswap.nix
-          ./nix/modules/config/hardware/supermicro/sys-5017a-ef.nix
-          ./nix/modules/config/hardware/supermicro/sys-5018d-fn4t.nix
-          ./nix/modules/config/hardware/supermicro/sys-5018d-mtln4f.nix
-          ./nix/modules/config/hardware/supermicro/mb-x10.nix
-          ./nix/modules/config/hardware/hwutils.nix
-          ./nix/modules/config/hardware/jetson-tk1.nix
-          ./nix/modules/config/hardware/jetson-tx1.nix
-          ./nix/modules/config/hardware/mbr.nix
-          ./nix/modules/config/hardware/uefi.nix
-          ./nix/modules/config/networking/tcp-bbr
-          ./nix/modules/config/nix/auto-gc
-          ./nix/modules/config/remote-builds/remote-build-host
-          ./nix/modules/config/remote-builds/build-host
-          ./nix/modules/core/module-hashes.nix
-          ./nix/modules/dns/unbound-multi-instance
-          ./nix/modules/networking/accept
-          ./nix/modules/networking/virtual-ips
-
-          ./nix/modules/services/tarsnapper
-          ./nix/modules/services/tftpd-hpa
-          ./nix/modules/services/vault/agent
-
-          ./nix/common/config/services/vault/agent/auth/approle
-          ./nix/common/config/services/vault/agent/template
-          ./nix/common/config/services/vault/agent/template/aws-credentials
-          ./nix/common/config/services/vault/agent/template/cachix
-          ./nix/common/config/services/vault/agent/template/flyctl
-          ./nix/common/config/services/vault/agent/template/github-credentials
-          ./nix/common/config/services/vault/agent/template/netrc
-        ];
-        nixpkgs.overlays = [ self.overlay ];
-      };
-
-      nixosConfigurations =
-        let
-          extraModules = [{
-            boot.isContainer = true;
-          }];
-          mkSystem = self.lib.hacknix.nixosSystem' extraModules;
-        in
-        self.lib.flakes.nixosConfigurations.importFromDirectory
-          mkSystem
-          ./examples/nixos
-          {
-            inherit (self) lib;
-            system = "x86_64-linux";
           };
 
-      darwinModule = {
-        imports = [
-          ./nix/darwinModules/config/defaults/default.nix
-          ./nix/darwinModules/config/defaults/nix.nix
-          ./nix/darwinModules/config/remote-builds/build-host
-          ./nix/darwinModules/config/remote-builds/remote-build-host
+          packages = {
+            inherit (pkgs) nmrpflash;
 
-          ./nix/darwinModules/config/services/vault-agent
+            inherit (pkgs) ffdhe2048Pem ffdhe3072Pem ffdhe4096Pem;
 
-          ./nix/common/config/services/vault/agent/auth/approle
-          ./nix/common/config/services/vault/agent/template
-          ./nix/common/config/services/vault/agent/template/aws-credentials
-          ./nix/common/config/services/vault/agent/template/cachix
-          ./nix/common/config/services/vault/agent/template/flyctl
+            # From sops-nix.
+            inherit (pkgs) sops-init-gpg-key sops-import-keys-hook ssh-to-pgp;
 
-          # Doesn't work yet as nix-darwin doesn't include a
-          # programs.git module.
-          #./nix/common/config/services/vault/agent/template/github-credentials
+            # These aren't actually derivations, and therefore, we
+            # can't export them from packages. They are in the overlay, however.
+            # inherit (pkgs) gitignoreSource gitignoreFilter;
+            # inherit (pkgs) lib;
+          } // (pkgs.lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux")
+            (
+              let
+                nixosGenerators =
+                  pkgs.lib.flakes.nixosGenerators.importFromDirectory
+                    pkgs.lib.hacknix.nixosGenerate
+                    ./examples/nixos
+                    {
+                      inherit pkgs;
+                      format = "lxc";
+                    };
 
-          ./nix/common/config/services/vault/agent/template/netrc
-        ];
-        nixpkgs.overlays = [ self.overlay ];
-      };
-
-      darwinConfigurations =
-        self.lib.flakes.darwinConfigurations.importFromDirectory
-          self.lib.hacknix.darwinSystem
-          ./examples/nix-darwin
-          {
-            inherit (self) lib;
-          };
-    }
-
-    // forAllSupportedSystems (system:
-    let
-      pkgs = pkgsFor system;
-
-      nixosGenerators =
-        self.lib.flakes.nixosGenerators.importFromDirectory
-          self.lib.hacknix.nixosGenerate
-          ./examples/nixos
-          {
-            inherit pkgs;
-            format = "lxc";
-          };
-    in
-    {
-      packages = self.lib.flakes.filterPackagesByPlatform system
-        {
-          inherit (pkgs) nmrpflash;
-
-          inherit (pkgs) ffdhe2048Pem ffdhe3072Pem ffdhe4096Pem;
-
-          # From sops-nix.
-          inherit (pkgs) sops-init-gpg-key sops-import-keys-hook ssh-to-pgp;
-
-          # These aren't actually derivations, and therefore, we
-          # can't export them from packages. They are in the overlay, however.
-          # inherit (pkgs) gitignoreSource gitignoreFilter;
-          # inherit (pkgs) lib;
-
-
-          # nixpkgs can't build with vz support on macOS, so we provide
-          # the option to use the upstream binary.
-          inherit (pkgs) lima-binary;
-        }
-      // (self.lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux")
-        (
-          let
-          in
-          {
-            inherit (nixosGenerators) remote-build-host build-host;
-
-            # Only available for Linux, but not detected properly by `filterPackagesByPlatform`.
-            inherit (pkgs) sops-install-secrets;
-          }
-        )
-      )
-      // {
-        inherit (pkgs) vaultenv;
-
-        # Until upstream is caught up.
-        inherit (pkgs) lima;
-        inherit (pkgs) colima;
-      };
-    })
-
-    // forAllSupportedSystems
-      (system:
-      let
-        pkgs = pkgsFor system;
-
-        pre-commit-hooks =
-          let
-          in
-          pre-commit-hooks-nix.lib.${system}.run {
-            src = ./.;
-            hooks = {
-              nixpkgs-fmt.enable = true;
-
-              prettier = {
-                enable = true;
-                excludes = [ ".github/" ];
-              };
-
-              actionlint = {
-                enable = true;
-                name = "actionlint";
-                entry = "${pkgs.actionlint}/bin/actionlint";
-                language = "system";
-                files = "^.github/workflows/";
-              };
-            };
-
-            tools = {
-              inherit (pkgs) nixpkgs-fmt;
-              inherit (pkgs.nodePackages) prettier;
-            };
-
-            excludes = [
-              "CODE_OF_CONDUCT.md"
-              "LICENSE"
-              ".mergify.yml"
-              ".buildkite/"
-            ];
-
-          };
-      in
-      {
-        checks = {
-          source-code-checks = pre-commit-hooks;
-        };
-
-        devShell = pkgs.mkShell {
-          buildInputs = (with pkgs; [
-            actionlint
-            nodePackages.prettier
-            nixpkgs-fmt
-            rnix-lsp
-          ]);
-
-          inherit (pre-commit-hooks) shellHook;
-        };
-      })
-
-    // {
-      hydraJobs =
-        {
-          inherit (self) packages checks;
-        }
-
-        // forAllLinuxCISystems (system: {
-          nixosConfigurations =
-            self.lib.flakes.nixosConfigurations.build
-              self.nixosConfigurations;
-        })
-
-        # Evaluation issues since we dropped x86_64-darwin.
-        # // {
-        #   darwinConfigurations = self.lib.flakes.darwinConfigurations.build self.darwinConfigurations;
-        # }
-
-        // forAllLinuxCISystems (system: {
-          tests =
-            let
-              pkgs = pkgsFor system;
-            in
-            (self.lib.testing.nixos.importFromDirectory ./tests/fixtures
+              in
               {
-                hostPkgs = pkgs;
-                defaults.imports = [ self.nixosModule ];
+                inherit (nixosGenerators) remote-build-host build-host;
+                inherit (pkgs) sops-install-secrets;
               }
             )
-            // (with import (nixpkgs + "/pkgs/top-level/release-lib.nix")
-              {
-                supportedSystems = [ system ];
-                scrubJobs = true;
-                nixpkgsArgs = {
-                  config = {
-                    allowUnfree = false;
-                    allowBroken = true;
-                    inHydra = true;
-                  };
-                  overlays = [
-                    self.overlay
-                    (import ./lib-tests)
-                  ];
-                };
-              };
-            mapTestOn {
-              dlnAttrSets = all;
-              dlnIPAddr = all;
-              dlnMisc = all;
-              dlnFfdhe = all;
-              dlnTypes = all;
-            });
-        })
+          ) // (pkgs.lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-darwin")
+            {
+              # Until upstream is caught up.
+              inherit (pkgs) lima;
+              inherit (pkgs) colima;
+            }
+          ) // (pkgs.lib.optionalAttrs (system == "aarch64-darwin")
+            {
+              # nixpkgs can't build with vz support on macOS, so we provide
+              # the option to use the upstream binary.
+              inherit (pkgs) lima-binary;
+            }
+          );
 
-        // {
-          required =
-            let
-              pkgs = pkgsFor "x86_64-linux";
-            in
-            pkgs.releaseTools.aggregate {
-              name = "required";
-              constituents = builtins.map builtins.attrValues (with self.hydraJobs; [
-                packages.x86_64-linux
-                packages.aarch64-linux
-                packages.aarch64-darwin
-                checks.x86_64-linux
-                checks.aarch64-linux
-                checks.aarch64-darwin
+          devShells.default = pkgs.mkShell {
+            buildInputs = (with pkgs; [
+              actionlint
+              nodePackages.prettier
+              nixpkgs-fmt
+              rnix-lsp
+            ]);
 
-                nixosConfigurations.x86_64-linux
 
-                # Evaluation issues since we dropped x86_64-darwin.
-                #darwinConfigurations
-
-                # These break evaluation for some reason.
-                #tests.x86_64-linux
-              ]);
-              meta.description = "Required CI builds";
-            };
+            shellHook = ''
+              ${config.pre-commit.installationScript}
+            '';
+          };
         };
 
-      ciJobs = self.lib.flakes.recurseIntoHydraJobs self.hydraJobs;
-    };
+        flake =
+          let
+            # See above, we need to use our own `pkgs` within the flake.
+            pkgs = import inputs.nixpkgs
+              {
+                system = "x86_64-linux";
+                config = {
+                  allowUnfree = true;
+                  allowBroken = true;
+                };
+                overlays = [ inputs.self.overlays.default ];
+              };
+          in
+          {
+            overlays = {
+              default =
+                let
+                  bootstrap = (import ./nix/overlays/000-bootstrap.nix) { } inputs.nixpkgs;
+                  overlaysFromDir = bootstrap.lib.overlays.combineFromDir ./nix/overlays;
+                in
+                bootstrap.lib.overlays.combine [
+                  (final: prev: {
+                    lib = (prev.lib or { }) // {
+
+                      flakes = (prev.lib.flakes or { }) // {
+                        # For some reason, the nixpkgs flake doesn't roll its local
+                        # lib.nixosSystem into nixpkgs.lib. We expose it here.
+                        inherit (inputs.nixpkgs.lib) nixosSystem;
+
+                        # Ditto for nix-darwin's lib.darwinSystem function.
+                        inherit (inputs.nix-darwin.lib) darwinSystem;
+
+                        inherit (inputs.nixos-generators) nixosGenerate;
+                      };
+
+                      hacknix = (prev.lib.hacknix or { }) // {
+                        flake = (prev.lib.hacknix.flake or { }) // {
+                          inherit inputs;
+                          inherit (inputs.self) darwinModules;
+                          inherit (inputs.self) nixosModules;
+                        };
+                      };
+                    };
+                  })
+                  inputs.sops-nix.overlay
+                  overlaysFromDir
+                ];
+            };
+
+            nixosModules = {
+              # Ideally, this would be refactored into multiple stand-alone
+              # modules, but many of these modules are interdependent at the
+              # moment, so we simply export them as a single module, for now.
+              hacknix = {
+                imports = [
+                  ./nix/modules/config/providers/ec2/default.nix
+                  ./nix/modules/config/providers/linode/default.nix
+                  ./nix/modules/config/providers/vultr/cloud/default.nix
+
+                  ./nix/modules/config/defaults/default.nix
+                  ./nix/modules/config/defaults/acme.nix
+                  ./nix/modules/config/defaults/environment.nix
+                  ./nix/modules/config/defaults/networking.nix
+                  ./nix/modules/config/defaults/nginx.nix
+                  ./nix/modules/config/defaults/nix.nix
+                  ./nix/modules/config/defaults/security.nix
+                  ./nix/modules/config/defaults/ssh.nix
+                  ./nix/modules/config/defaults/sudo.nix
+                  ./nix/modules/config/defaults/system.nix
+                  ./nix/modules/config/defaults/tmux.nix
+                  ./nix/modules/config/defaults/users.nix
+
+                  ./nix/modules/config/services/freeradius
+
+                  ./nix/modules/config/hardware/amd/common.nix
+                  ./nix/modules/config/hardware/amd/jaguar.nix
+                  ./nix/modules/config/hardware/apu2/apu3c4.nix
+                  ./nix/modules/config/hardware/intel/broadwell-de.nix
+                  ./nix/modules/config/hardware/intel/centerton.nix
+                  ./nix/modules/config/hardware/intel/coffee-lake.nix
+                  ./nix/modules/config/hardware/intel/common.nix
+                  ./nix/modules/config/hardware/intel/haswell.nix
+                  ./nix/modules/config/hardware/intel/kaby-lake.nix
+                  ./nix/modules/config/hardware/intel/sandy-bridge.nix
+                  ./nix/modules/config/hardware/smartd/1x-non-removable.nix
+                  ./nix/modules/config/hardware/smartd/2x-non-removable.nix
+                  ./nix/modules/config/hardware/smartd/36x-hotswap.nix
+                  ./nix/modules/config/hardware/smartd/4x-hotswap.nix
+                  ./nix/modules/config/hardware/supermicro/sys-5017a-ef.nix
+                  ./nix/modules/config/hardware/supermicro/sys-5018d-fn4t.nix
+                  ./nix/modules/config/hardware/supermicro/sys-5018d-mtln4f.nix
+                  ./nix/modules/config/hardware/supermicro/mb-x10.nix
+                  ./nix/modules/config/hardware/hwutils.nix
+                  ./nix/modules/config/hardware/jetson-tk1.nix
+                  ./nix/modules/config/hardware/jetson-tx1.nix
+                  ./nix/modules/config/hardware/mbr.nix
+                  ./nix/modules/config/hardware/uefi.nix
+
+                  ./nix/modules/config/networking/tcp-bbr
+
+                  ./nix/modules/config/nix/auto-gc
+
+                  ./nix/modules/config/remote-builds/remote-build-host
+                  ./nix/modules/config/remote-builds/build-host
+
+                  ./nix/modules/core/module-hashes.nix
+
+                  ./nix/modules/dns/unbound-multi-instance
+
+                  ./nix/modules/networking/accept
+                  ./nix/modules/networking/virtual-ips
+
+                  ./nix/modules/services/tarsnapper
+                  ./nix/modules/services/tftpd-hpa
+                  ./nix/modules/services/vault/agent
+
+                  ./nix/common/config/services/vault/agent/auth/approle
+                  ./nix/common/config/services/vault/agent/template
+                  ./nix/common/config/services/vault/agent/template/aws-credentials
+                  ./nix/common/config/services/vault/agent/template/cachix
+                  ./nix/common/config/services/vault/agent/template/flyctl
+                  ./nix/common/config/services/vault/agent/template/github-credentials
+                  ./nix/common/config/services/vault/agent/template/netrc
+                ];
+                nixpkgs.overlays = [ inputs.self.overlays.default ];
+              };
+            };
+
+            darwinModules = {
+              hacknix = {
+                imports = [
+                  ./nix/darwinModules/config/defaults/default.nix
+                  ./nix/darwinModules/config/defaults/nix.nix
+                  ./nix/darwinModules/config/remote-builds/build-host
+                  ./nix/darwinModules/config/remote-builds/remote-build-host
+
+                  ./nix/darwinModules/config/services/vault-agent
+
+                  ./nix/common/config/services/vault/agent/auth/approle
+                  ./nix/common/config/services/vault/agent/template
+                  ./nix/common/config/services/vault/agent/template/aws-credentials
+                  ./nix/common/config/services/vault/agent/template/cachix
+                  ./nix/common/config/services/vault/agent/template/flyctl
+
+                  # Doesn't work yet as nix-darwin doesn't include a
+                  # programs.git module.
+                  #./nix/common/config/services/vault/agent/template/github-credentials
+
+                  ./nix/common/config/services/vault/agent/template/netrc
+                ];
+                nixpkgs.overlays = [ inputs.self.overlays.default ];
+              };
+            };
+
+            nixosConfigurations =
+              let
+                extraModules = [{
+                  boot.isContainer = true;
+                }];
+                mkSystem = pkgs.lib.hacknix.nixosSystem' extraModules;
+              in
+              pkgs.lib.flakes.nixosConfigurations.importFromDirectory
+                mkSystem
+                ./examples/nixos
+                {
+                  inherit (pkgs) lib;
+                  system = "x86_64-linux";
+                };
+
+            darwinConfigurations =
+              pkgs.lib.flakes.darwinConfigurations.importFromDirectory
+                pkgs.lib.hacknix.darwinSystem
+                ./examples/nix-darwin
+                {
+                  inherit (pkgs) lib;
+                };
+
+            hydraJobs = {
+              inherit (inputs.self) checks;
+              inherit (inputs.self) packages;
+              inherit (inputs.self) devShells;
+
+              nixosConfigurations = pkgs.lib.flakes.nixosConfigurations.build
+                inputs.self.nixosConfigurations;
+
+              darwinConfigurations = pkgs.lib.flakes.darwinConfigurations.build
+                inputs.self.darwinConfigurations;
+
+              required = pkgs.releaseTools.aggregate {
+                name = "required-nix-ci";
+                constituents = builtins.map builtins.attrValues (with inputs.self.hydraJobs; [
+                  packages
+                  checks.x86_64-linux
+                  checks.aarch64-linux
+                  checks.aarch64-darwin
+
+                  nixosConfigurations
+                  darwinConfigurations
+                ]);
+                meta.description = "Required Nix CI builds";
+              };
+            };
+
+            ciJobs = pkgs.lib.flakes.recurseIntoHydraJobs inputs.self.hydraJobs;
+          };
+      };
 }

--- a/nix/overlays/130-lib-hacknix.nix
+++ b/nix/overlays/130-lib-hacknix.nix
@@ -1,7 +1,7 @@
 final: prev:
 let
   hacknixExtraModules = [
-    final.lib.hacknix.flake.nixosModules.hacknix
+    final.lib.hacknix.flake.nixosModules.default
     final.lib.hacknix.flake.inputs.sops-nix.nixosModules.sops
   ];
 
@@ -16,7 +16,7 @@ let
   isoImage = extraModules:
     final.lib.flakes.isoImage (hacknixExtraModules ++ extraModules);
   darwinSystem' = extraModules:
-    final.lib.flakes.darwinSystem' ([ final.lib.hacknix.flake.darwinModules.hacknix ] ++ extraModules);
+    final.lib.flakes.darwinSystem' ([ final.lib.hacknix.flake.darwinModules.default ] ++ extraModules);
   darwinSystem = darwinSystem' [ ];
   nixosGenerate' = extraModules:
     final.lib.flakes.nixosGenerate' (hacknixExtraModules ++ extraModules);

--- a/nix/overlays/130-lib-hacknix.nix
+++ b/nix/overlays/130-lib-hacknix.nix
@@ -1,7 +1,7 @@
 final: prev:
 let
   hacknixExtraModules = [
-    final.lib.hacknix.flake.nixosModule
+    final.lib.hacknix.flake.nixosModules.hacknix
     final.lib.hacknix.flake.inputs.sops-nix.nixosModules.sops
   ];
 
@@ -16,7 +16,7 @@ let
   isoImage = extraModules:
     final.lib.flakes.isoImage (hacknixExtraModules ++ extraModules);
   darwinSystem' = extraModules:
-    final.lib.flakes.darwinSystem' ([ final.lib.hacknix.flake.darwinModule ] ++ extraModules);
+    final.lib.flakes.darwinSystem' ([ final.lib.hacknix.flake.darwinModules.hacknix ] ++ extraModules);
   darwinSystem = darwinSystem' [ ];
   nixosGenerate' = extraModules:
     final.lib.flakes.nixosGenerate' (hacknixExtraModules ++ extraModules);


### PR DESCRIPTION
This doesn't massively simplify the flake, but it helps a bit, and a few `hydraJobs` that used to not work, now do.

Note that this will break downstream users, because the flake's overlays and modules have changed structure. However, the fixes are trivial.