### PR TITLE
chore: make remote builder SSH hostkeys optional

### DIFF
--- a/examples/nix-darwin/build-host.nix
+++ b/examples/nix-darwin/build-host.nix
@@ -25,6 +25,18 @@
             supportedFeatures = [ "big-parallel" "kvm" "nixos-test" ];
             sshUserName = "remote-builder";
           };
+
+          # A build machine with no associated public key. This might
+          # be useful when using an SSH CA for host keys.
+          remote-builder-no-hostkey = {
+            hostName = "remote-builder-no-hostkey.example.com";
+            alternateHostNames = [ "192.0.2.2" "2001:db8::2" ];
+            systems = [ "x86_64-linux" "i686-linux" ];
+            maxJobs = 4;
+            speedFactor = 1;
+            supportedFeatures = [ "big-parallel" "kvm" "nixos-test" ];
+            sshUserName = "remote-builder";
+          };
         };
       };
 

--- a/examples/nixos/build-host.nix
+++ b/examples/nixos/build-host.nix
@@ -25,6 +25,18 @@ args // {
             supportedFeatures = [ "big-parallel" "kvm" "nixos-test" ];
             sshUserName = "remote-builder";
           };
+
+          # A build machine with no associated public key. This might
+          # be useful when using an SSH CA for host keys.
+          remote-builder-no-hostkey = {
+            hostName = "remote-builder-no-hostkey.example.com";
+            alternateHostNames = [ "192.0.2.2" "2001:db8::2" ];
+            systems = [ "x86_64-linux" "i686-linux" ];
+            maxJobs = 4;
+            speedFactor = 1;
+            supportedFeatures = [ "big-parallel" "kvm" "nixos-test" ];
+            sshUserName = "remote-builder";
+          };
         };
 
         # Use Vault to issue SSH CA-signed keys for the remote builder.

--- a/nix/overlays/130-lib-hacknix.nix
+++ b/nix/overlays/130-lib-hacknix.nix
@@ -54,7 +54,9 @@ let
           publicKey = descriptor.hostPublicKeyLiteral;
         }
       )
-      remoteBuildHosts;
+      (final.lib.filterAttrs
+        (name: descriptor: descriptor.hostPublicKeyLiteral != null)
+        remoteBuildHosts);
 
   # Given a set of remote build hosts of the hacknix remoteBuildHost
   # type, filter the set so that it only contains Macs.

--- a/nix/overlays/131-lib-more-types.nix
+++ b/nix/overlays/131-lib-more-types.nix
@@ -440,7 +440,8 @@ let
       };
 
       hostPublicKeyLiteral = final.lib.mkOption {
-        type = final.lib.types.nonEmptyStr;
+        type = final.lib.types.nullOr final.lib.types.nonEmptyStr;
+        default = null;
         example =
           "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMUTz5i9u5H2FHNAmZJyoJfIGyUm/HfGhfwnc142L3ds";
         description = ''


### PR DESCRIPTION
This is helpful for using an SSH host key CA.