### PR TITLE
fix: revive `nixosGenerators`

### DIFF
--- a/examples/nixos/build-host.nix
+++ b/examples/nixos/build-host.nix
@@ -39,6 +39,10 @@ args // {
           };
         };
 
+        environment.systemPackages = with pkgs; [
+          cachix-archive-flake-inputs
+        ];
+
         # Use Vault to issue SSH CA-signed keys for the remote builder.
         services.vault-agent.template.remote-builder-ssh.enable = true;
 

--- a/flake.nix
+++ b/flake.nix
@@ -109,9 +109,12 @@
               in
               {
                 remote-build-host-lxc = lxc.remote-build-host;
-                remote-build-host-qcow = qcow.remote-build-host;
                 build-host-lxc = lxc.build-host;
-                build-host-qcow = qcow.build-host;
+
+                # Disabled until we have `kvm` support in CI again.
+
+                #remote-build-host-qcow = qcow.remote-build-host;
+                #build-host-qcow = qcow.build-host;
               }
             )
           );

--- a/flake.nix
+++ b/flake.nix
@@ -90,20 +90,28 @@
           } // (pkgs.lib.optionalAttrs (system == "x86_64-linux")
             (
               let
-                nixosGenerators =
+                lxc =
                   pkgs.lib.flakes.nixosGenerators.importFromDirectory
                     pkgs.lib.hacknix.nixosGenerate
                     ./examples/nixos
                     {
-                      inherit pkgs;
                       format = "lxc";
+                    };
+
+                qcow =
+                  pkgs.lib.flakes.nixosGenerators.importFromDirectory
+                    pkgs.lib.hacknix.nixosGenerate
+                    ./examples/nixos
+                    {
+                      format = "qcow";
                     };
 
               in
               {
-                # Currently broken due to this change:
-                # https://github.com/NixOS/nixpkgs/pull/258447
-                #inherit (nixosGenerators) remote-build-host build-host;
+                remote-build-host-lxc = lxc.remote-build-host;
+                remote-build-host-qcow = qcow.remote-build-host;
+                build-host-lxc = lxc.build-host;
+                build-host-qcow = qcow.build-host;
               }
             )
           );


### PR DESCRIPTION
Turns out we no longer need to `import pkgs`; the flake's own packages are used by default. Just to be sure, we add one of our overlay's packages to the `build-host` image.

We also now build both LXC and qcow2 images, for completeness.