### PR TITLE
chore(nix): enable the macOS sandbox, with caveats

### DIFF
--- a/nix/darwinModules/config/defaults/default.nix
+++ b/nix/darwinModules/config/defaults/default.nix
@@ -30,19 +30,17 @@ in
 
     nix.settings.trusted-users = [ "@admin" ];
 
-    # See https://gist.github.com/LnL7/1cfca66d17eba1f9936175926bf39de8.
+    # Enable the sandbox, but in order to work around issues with
+    # packages requiring too many paths, we add `/nix/store` by
+    # default. This is less than optimal, but much safer than
+    # disabling the sandbox entirely, and probably safer than
+    # disabling the sandbox on a per-package, as-needed basis, as
+    # well.
     #
-    # XXX dhess - disabled, see:
-    # https://github.com/NixOS/nix/issues/2311
-    # nix.useSandbox = true;
-    # nix.sandboxPaths = [
-    #   "/System/Library/Frameworks"
-    #   "/System/Library/PrivateFrameworks"
-    #   "/usr/lib"
-    #   "/private/tmp"
-    #   "/private/var/tmp"
-    #   "/usr/bin/env"
-    # ];
+    # Ref:
+    # https://github.com/NixOS/nix/issues/4119#issuecomment-2561973914
+    nix.settings.sandbox = true;
+    nix.settings.extra-sandbox-paths = [ "/nix/store" ];
 
     # We always run nix-daemon (multi-user mode).
     services.nix-daemon.enable = true;


### PR DESCRIPTION
It seems like most of the macOS sandbox issues have been resolved, except for the 64K sandbox program limit.

Here we enable the sandbox, but in order to work around this limit, we add `/nix/store` to the allowed paths by default. (Presumably the sandbox compiler is smart enough to replace multiple `/nix/store/...` paths with a single `/nix/store` parent path.)

This is less than optimal, but much safer than disabling the sandbox entirely, and probably safer than disabling the sandbox on a per-package, as-needed basis, as well.

Ref:
https://github.com/NixOS/nix/issues/4119#issuecomment-2561973914

Also see:

https://github.com/NixOS/nixpkgs/pull/346945
https://github.com/NixOS/nix/issues/6836
https://github.com/NixOS/nix/issues/4119
https://github.com/amarshall/home-manager/commit/d7319b754802fe5f9a5c2b7db375a3331779d27d https://github.com/NixOS/nixpkgs/issues/366245
https://github.com/NixOS/nix/issues/2311