### PR TITLE
chore(nix): back to `github:`-style flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,12 +5,15 @@
       "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/flake-compat/archive/master.tar.gz"
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/flake-compat/archive/master.tar.gz"
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
       }
     },
     "flake-compat_2": {
@@ -36,12 +39,15 @@
       "locked": {
         "lastModified": 1775087534,
         "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
-        "type": "tarball",
-        "url": "https://github.com/hercules-ci/flake-parts/archive/main.tar.gz"
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/hercules-ci/flake-parts/archive/main.tar.gz"
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
       }
     },
     "gitignore": {
@@ -70,12 +76,15 @@
       "locked": {
         "lastModified": 1762808025,
         "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
-        "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore.nix/archive/master.tar.gz"
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore.nix/archive/master.tar.gz"
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
       }
     },
     "nix-darwin": {
@@ -87,24 +96,30 @@
       "locked": {
         "lastModified": 1775037210,
         "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
-        "type": "tarball",
-        "url": "https://github.com/nix-darwin/nix-darwin/archive/master.tar.gz"
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/nix-darwin/nix-darwin/archive/master.tar.gz"
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775403759,
-        "narHash": "sha256-cGyKiTspHEUx3QwAnV3RfyT+VOXhHLs+NEr17HU34Wo=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz"
+        "lastModified": 1775587025,
+        "narHash": "sha256-6HfkaOCMnloC5/9a3g77Ysg6s31OqaHPba2PNe6FKIw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ab5ff095a09004a59654c1f83cf7a0b0655527fe",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz"
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-lib": {
@@ -131,14 +146,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1775036584,
-        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
-        "type": "tarball",
-        "url": "https://github.com/cachix/git-hooks.nix/archive/master.tar.gz"
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/cachix/git-hooks.nix/archive/master.tar.gz"
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
       }
     },
     "root": {
@@ -161,12 +179,15 @@
       "locked": {
         "lastModified": 1775125835,
         "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
-        "type": "tarball",
-        "url": "https://github.com/numtide/treefmt-nix/archive/main.tar.gz"
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "75925962939880974e3ab417879daffcba36c4a3",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/numtide/treefmt-nix/archive/main.tar.gz"
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,24 +2,24 @@
   description = "Hackworth Ltd Nix.";
 
   inputs = {
-    nixpkgs.url = "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz";
+    nixpkgs.url = "github:NixOS/nixpkgs";
 
-    nix-darwin.url = "https://github.com/nix-darwin/nix-darwin/archive/master.tar.gz";
+    nix-darwin.url = "github:nix-darwin/nix-darwin";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
 
-    flake-compat.url = "https://github.com/NixOS/flake-compat/archive/master.tar.gz";
+    flake-compat.url = "github:NixOS/flake-compat";
     flake-compat.flake = false;
 
-    gitignore-nix.url = "https://github.com/hercules-ci/gitignore.nix/archive/master.tar.gz";
+    gitignore-nix.url = "github:hercules-ci/gitignore.nix";
     gitignore-nix.flake = false;
 
-    treefmt-nix.url = "https://github.com/numtide/treefmt-nix/archive/main.tar.gz";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
-    pre-commit-hooks-nix.url = "https://github.com/cachix/git-hooks.nix/archive/master.tar.gz";
+    pre-commit-hooks-nix.url = "github:cachix/git-hooks.nix";
     pre-commit-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
 
-    flake-parts.url = "https://github.com/hercules-ci/flake-parts/archive/main.tar.gz";
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
   outputs =


### PR DESCRIPTION
Tarballs don't work well with CI, because the Nix flake system can't retrieve the tarballs by SHA, so they're not stable targets.